### PR TITLE
Use `otel4s-sdk-trace-testkit` to run tests across all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: examples_2.13 examples_3 site_2.13 site_3 sbt-http4s-org-scalafix-internal_2.13 sbt-http4s-org-scalafix-internal_3 http4s-otel4s-middlewarejvm_2.13 http4s-otel4s-middlewarejvm_3 http4s-otel4s-middlewarejs_2.13 http4s-otel4s-middlewarejs_3 http4s-otel4s-middlewarenative_2.13 http4s-otel4s-middlewarenative_3 core-jvm-tests_2.13 core-jvm-tests_3
+          modules-ignore: examples_2.13 examples_3 site_2.13 site_3 sbt-http4s-org-scalafix-internal_2.13 sbt-http4s-org-scalafix-internal_3 http4s-otel4s-middlewarejvm_2.13 http4s-otel4s-middlewarejvm_3 http4s-otel4s-middlewarejs_2.13 http4s-otel4s-middlewarejs_3 http4s-otel4s-middlewarenative_2.13 http4s-otel4s-middlewarenative_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   site:

--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,10 @@ ThisBuild / scalaVersion := scala213
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 ThisBuild / tlJdkRelease := Some(8)
 
-ThisBuild / testFrameworks += new TestFramework("munit.Framework")
-
 val catsV = "2.10.0"
 val catsEffectV = "3.5.4"
 val http4sV = "0.23.26"
-val munitV = "0.7.29"
+val munitV = "1.0.0-RC1"
 val munitCatsEffectV = "2.0.0-M5"
 val openTelemetryV = "1.35.0"
 val otel4sV = "0.5.0"
@@ -29,7 +27,7 @@ val slf4jV = "1.7.36"
 
 // Projects
 lazy val `http4s-otel4s-middleware` = tlCrossRootProject
-  .aggregate(core, `core-jvm-tests`, examples)
+  .aggregate(core, examples)
 
 lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -42,21 +40,11 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.http4s" %%% "http4s-client" % http4sV,
       "org.typelevel" %%% "otel4s-core-trace" % otel4sV,
       "org.typelevel" %%% "otel4s-semconv" % otel4sV,
-      "org.scalameta" %% "munit" % munitV % Test,
-    ),
-  )
-
-lazy val `core-jvm-tests` = project
-  .in(file("core-jvm-tests"))
-  .enablePlugins(NoPublishPlugin)
-  .dependsOn(core.jvm)
-  .settings(
-    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "otel4s-sdk-trace-testkit" % otel4sV % Test,
       "org.typelevel" %%% "cats-effect-testkit" % catsEffectV % Test,
       "org.typelevel" %%% "munit-cats-effect" % munitCatsEffectV % Test,
-      "org.typelevel" %%% "otel4s-oteljava-trace" % otel4sV % Test,
-      "org.typelevel" %%% "otel4s-oteljava-trace-testkit" % otel4sV % Test,
-    )
+      "org.scalameta" %%% "munit" % munitV % Test,
+    ),
   )
 
 lazy val examples = project

--- a/core/src/test/scala/org/http4s/otel4s/middleware/ClientMiddlewareTests.scala
+++ b/core/src/test/scala/org/http4s/otel4s/middleware/ClientMiddlewareTests.scala
@@ -17,8 +17,6 @@
 package org.http4s.otel4s.middleware
 
 import cats.effect.IO
-import io.opentelemetry.api.trace.{SpanKind => JSpanKind}
-import io.opentelemetry.sdk.trace.data.{SpanData => JSpanData}
 import munit.CatsEffectSuite
 import org.http4s.Header
 import org.http4s.Headers
@@ -31,8 +29,8 @@ import org.http4s.client.Client
 import org.http4s.syntax.literals._
 import org.typelevel.ci.CIStringSyntax
 import org.typelevel.otel4s.AttributeKey
-import org.typelevel.otel4s.oteljava.AttributeConverters._
-import org.typelevel.otel4s.oteljava.testkit.trace.TracesTestkit
+import org.typelevel.otel4s.sdk.testkit.trace.TracesTestkit
+import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.Tracer
 
 class ClientMiddlewareTests extends CatsEffectSuite {
@@ -63,14 +61,14 @@ class ClientMiddlewareTests extends CatsEffectSuite {
                 .withHeaders(headers)
             tracedClient.run(request).use(_.body.compile.drain)
           }
-          spans <- testkit.finishedSpans[JSpanData]
+          spans <- testkit.finishedSpans
         } yield {
           assertEquals(spans.length, 1)
           val span = spans.head
-          assertEquals(span.getName, "Http Client - GET")
-          assertEquals(span.getKind, JSpanKind.CLIENT)
+          assertEquals(span.name, "Http Client - GET")
+          assertEquals(span.kind, SpanKind.Client)
 
-          val attributes = span.getAttributes.toScala
+          val attributes = span.attributes
           assertEquals(attributes.size, 11)
           def getAttr[A: AttributeKey.KeySelect](name: String): Option[A] =
             attributes.get[A](name).map(_.value)

--- a/core/src/test/scala/org/http4s/otel4s/middleware/ServerMiddlewareTests.scala
+++ b/core/src/test/scala/org/http4s/otel4s/middleware/ServerMiddlewareTests.scala
@@ -17,8 +17,6 @@
 package org.http4s.otel4s.middleware
 
 import cats.effect.IO
-import io.opentelemetry.api.trace.{SpanKind => JSpanKind}
-import io.opentelemetry.sdk.trace.data.{SpanData => JSpanData}
 import munit.CatsEffectSuite
 import org.http4s.Header
 import org.http4s.Headers
@@ -30,8 +28,8 @@ import org.http4s.Status
 import org.http4s.syntax.literals._
 import org.typelevel.ci.CIStringSyntax
 import org.typelevel.otel4s.AttributeKey
-import org.typelevel.otel4s.oteljava.AttributeConverters._
-import org.typelevel.otel4s.oteljava.testkit.trace.TracesTestkit
+import org.typelevel.otel4s.sdk.testkit.trace.TracesTestkit
+import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.Tracer
 
 class ServerMiddlewareTests extends CatsEffectSuite {
@@ -58,14 +56,14 @@ class ServerMiddlewareTests extends CatsEffectSuite {
                 .withHeaders(headers)
             tracedServer.run(request)
           }
-          spans <- testkit.finishedSpans[JSpanData]
+          spans <- testkit.finishedSpans
         } yield {
           assertEquals(spans.length, 1)
           val span = spans.head
-          assertEquals(span.getName, "Http Server - GET")
-          assertEquals(span.getKind, JSpanKind.SERVER)
+          assertEquals(span.name, "Http Server - GET")
+          assertEquals(span.kind, SpanKind.Server)
 
-          val attributes = span.getAttributes.toScala
+          val attributes = span.attributes
           assertEquals(attributes.size, 11)
           def getAttr[A: AttributeKey.KeySelect](name: String): Option[A] =
             attributes.get[A](name).map(_.value)


### PR DESCRIPTION
We can use `otel4s-sdk-trace-testkit` to run tests across all platforms. 

Side note: there is still a chance `otel4s-sdk` and `otel4s-oteljava` may behave slightly different in non-trivial cases. However, a shared [test suite](https://github.com/typelevel/otel4s/blob/main/core/trace/src/test/scala/org/typelevel/otel4s/trace/BaseTracerSuite.scala) ensures both implementations behave identically in the most **common** scenarios. 