### PR TITLE
Allow client middlewares to manipulate spans

### DIFF
--- a/core/src/main/scala/org/http4s/otel4s/middleware/ClientMiddleware.scala
+++ b/core/src/main/scala/org/http4s/otel4s/middleware/ClientMiddleware.scala
@@ -164,8 +164,9 @@ object ClientMiddleware {
                       }
                       .mapK(trace)
                   }
-                case Outcome.Errored(e) =>
-                  Resource.eval(span.recordException(e)).mapK(trace)
+                case Outcome.Errored(_) =>
+                  // As client.run is traced, any exception thrown by it is already recorded
+                  Resource.unit[F]
                 case Outcome.Canceled() =>
                   // Canceled isn't always an error, but it generally is for http
                   // TODO: decide if this should add "error", we do for the server side.

--- a/core/src/main/scala/org/http4s/otel4s/middleware/ClientMiddleware.scala
+++ b/core/src/main/scala/org/http4s/otel4s/middleware/ClientMiddleware.scala
@@ -151,7 +151,7 @@ object ClientMiddleware {
             trace = res.trace
             traceHeaders <- Resource.eval(Tracer[F].propagate(Headers.empty)).mapK(trace)
             newReq = req.withHeaders(traceHeaders ++ req.headers)
-            resp <- poll(client.run(newReq)).guaranteeCase { outcome =>
+            resp <- poll(client.run(newReq)).mapK(trace).guaranteeCase { outcome =>
               (outcome match {
                 case Outcome.Succeeded(fa) =>
                   fa.flatMap { resp =>


### PR DESCRIPTION
Apply the context to the inner client so that middlewares already applied to it can manipulate the created span.

This allows for several use cases, including setting the span name based on higher-level http libraries like smithy4s that allow extraction of http.route. It also facilitates logging middlewares as the span ID can be properly extracted, before they ended up with the parent span ID.