### PR TITLE
Allow overriding span name by request attribute

### DIFF
--- a/core/src/main/scala/org/http4s/otel4s/middleware/ClientMiddleware.scala
+++ b/core/src/main/scala/org/http4s/otel4s/middleware/ClientMiddleware.scala
@@ -142,7 +142,9 @@ object ClientMiddleware {
         MonadCancelThrow[Resource[F, *]].uncancelable { poll =>
           for {
             res <- Tracer[F]
-              .spanBuilder(clientSpanName(reqPrelude))
+              .spanBuilder(
+                req.attributes.lookup(OverrideSpanNameKey).getOrElse(clientSpanName(reqPrelude))
+              )
               .withSpanKind(SpanKind.Client)
               .addAttributes(base)
               .build
@@ -189,6 +191,12 @@ object ClientMiddleware {
   /** A key used to attach additional `Attribute`s to a request or response. */
   val ExtraAttributesKey: Key[Attributes] =
     Key.newKey[SyncIO, Attributes].unsafeRunSync()
+
+  /** A key used to override the span name for a specific request. If set, this attribute takes precedence over
+    *  anything configured through [[ClientMiddlewareBuilder.withClientSpanName]].
+    */
+  val OverrideSpanNameKey: Key[String] =
+    Key.newKey[SyncIO, String].unsafeRunSync()
 
   /** @return the default `Attribute`s for a request */
   private def request[F[_]](

--- a/core/src/test/scala/org/http4s/otel4s/middleware/ClientMiddlewareTests.scala
+++ b/core/src/test/scala/org/http4s/otel4s/middleware/ClientMiddlewareTests.scala
@@ -89,4 +89,36 @@ class ClientMiddlewareTests extends CatsEffectSuite {
         }
       }
   }
+
+  test("ClientMiddleware allows overriding span name") {
+    val spanName = "Overridden span name"
+    TracesTestkit
+      .inMemory[IO]()
+      .use { testkit =>
+        for {
+          tracerIO <- testkit.tracerProvider.get("tracer")
+          _ <- {
+            implicit val tracer: Tracer[IO] = tracerIO
+            val response = Response[IO](Status.Ok)
+            val fakeClient =
+              Client.fromHttpApp[IO] {
+                HttpApp[IO](_.body.compile.drain.as(response))
+              }
+            val tracedClient =
+              ClientMiddleware
+                .default[IO]
+                .build(fakeClient)
+
+            val request = Request[IO](Method.GET, uri"http://localhost/?#")
+              .withAttribute(ClientMiddleware.OverrideSpanNameKey, spanName)
+            tracedClient.run(request).use(_.body.compile.drain)
+          }
+          spans <- testkit.finishedSpans
+        } yield {
+          assertEquals(spans.length, 1)
+          val span = spans.head
+          assertEquals(span.name, spanName)
+        }
+      }
+  }
 }


### PR DESCRIPTION
To make interop with HTTP libraries like smithy4s easier, allow overriding the span name through a request attribute. This works very similar to the existing `ExtraAttributesKey`.