### PR TITLE
Improve API and implementation

### DIFF
--- a/examples/src/main/scala/example/Http4sExample.scala
+++ b/examples/src/main/scala/example/Http4sExample.scala
@@ -85,6 +85,7 @@ object Http4sExample extends IOApp with Common {
       metricsOps <- OtelMetrics.serverMetricsOps[F]().toResource
       app <- ServerMiddlewareBuilder
         .default[F](redactor)
+        .withRouteClassifier(routeClassifier)
         .buildHttpApp {
           Metrics(metricsOps)(routes(client)).orNotFound
         }

--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareBuilder.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareBuilder.scala
@@ -91,6 +91,7 @@ class ClientMiddlewareBuilder[F[_]: TracerProvider: Concurrent] private (
       tracer <- TracerProvider[F]
         .tracer("org.http4s.otel4s.middleware.client")
         .withVersion(org.http4s.otel4s.middleware.BuildInfo.version)
+        .withSchemaUrl("https://opentelemetry.io/schemas/1.29.0")
         .get
     } yield (client: Client[F]) =>
       Client[F] { (req: Request[F]) => // Resource[F, Response[F]]

--- a/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareTest.scala
+++ b/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareTest.scala
@@ -43,8 +43,8 @@ import org.typelevel.otel4s.trace.TracerProvider
 import scala.concurrent.duration.Duration
 import scala.util.control.NoStackTrace
 
-class ClientMiddlewareTests extends CatsEffectSuite {
-  import ClientMiddlewareTests.MinimalRedactor
+class ClientMiddlewareTest extends CatsEffectSuite {
+  import ClientMiddlewareTest.MinimalRedactor
 
   private val spanLimits = SpanLimits.default
 
@@ -474,6 +474,6 @@ class ClientMiddlewareTests extends CatsEffectSuite {
   }
 }
 
-object ClientMiddlewareTests {
+object ClientMiddlewareTest {
   object MinimalRedactor extends UriRedactor.OnlyRedactUserInfo
 }

--- a/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/SpanDataProviderTest.scala
+++ b/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/SpanDataProviderTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package otel4s.middleware.trace.client
+
+import munit.FunSuite
+import munit.Location
+import org.typelevel.ci.CIString
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+
+class SpanDataProviderTest extends FunSuite {
+  import SpanDataProviderTest._
+
+  private[this] def check(
+      output: Attributes,
+      keys: Seq[String],
+      last: String,
+  )(implicit loc: Location): Unit =
+    assertEquals(
+      output,
+      keys.map(k => Attribute(s"test.key.$k", 1L)).to(Attributes) + Attribute("test.last", last),
+    )
+
+  test("and") {
+    val a = new SimpleAttributeProvider("a")
+    val b = new SimpleAttributeProvider("b")
+    val c = new SimpleSpanDataProvider("c")
+    val d = new SimpleSpanDataProvider("d")
+
+    val cabd = c.and(a.and(b).and(d))
+    assertEquals(cabd.spanName(null, null, null, null.asInstanceOf[cabd.Shared]), "c")
+    check(cabd.requestAttributes(null, null, null, null), Seq("a", "b", "c", "d"), "d")
+    check(cabd.responseAttributes(null, null), Seq("a", "b", "c", "d"), "d")
+    check(cabd.exceptionAttributes(null), Seq("a", "b", "c", "d"), "d")
+
+    val db = d.and(b)
+    assertEquals(db.spanName(null, null, null, null.asInstanceOf[db.Shared]), "d")
+    check(db.requestAttributes(null, null, null, null), Seq("b", "d"), "b")
+    check(db.responseAttributes(null, null), Seq("b", "d"), "b")
+    check(db.exceptionAttributes(null), Seq("b", "d"), "b")
+  }
+}
+
+object SpanDataProviderTest {
+  private[this] def attr(name: String): Attributes =
+    Attributes(Attribute(s"test.key.$name", 1L), Attribute("test.last", name))
+
+  private final class SimpleAttributeProvider(name: String) extends AttributeProvider {
+    def requestAttributes[F[_]](
+        request: Request[F],
+        urlTemplateClassifier: UriTemplateClassifier,
+        urlRedactor: UriRedactor,
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes = attr(name)
+    def responseAttributes[F[_]](
+        response: Response[F],
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes = attr(name)
+    def exceptionAttributes(cause: Throwable): Attributes =
+      attr(name)
+  }
+
+  private final class SimpleSpanDataProvider(name: String) extends SpanDataProvider {
+    type Shared = Null
+    def processSharedData[F[_]](
+        request: Request[F],
+        urlTemplateClassifier: UriTemplateClassifier,
+        urlRedactor: UriRedactor,
+    ): Null = null
+    def spanName[F[_]](
+        request: Request[F],
+        urlTemplateClassifier: UriTemplateClassifier,
+        urlRedactor: UriRedactor,
+        sharedProcessedData: Null,
+    ): String = name
+    def requestAttributes[F[_]](
+        request: Request[F],
+        urlTemplateClassifier: UriTemplateClassifier,
+        urlRedactor: UriRedactor,
+        sharedProcessedData: Null,
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes = attr(name)
+    def responseAttributes[F[_]](
+        response: Response[F],
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes = attr(name)
+    def exceptionAttributes(cause: Throwable): Attributes =
+      attr(name)
+  }
+}

--- a/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/UriTemplateClassifierTest.scala
+++ b/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/UriTemplateClassifierTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package otel4s.middleware.trace.client
+
+import munit.FunSuite
+import org.http4s.syntax.literals._
+
+class UriTemplateClassifierTest extends FunSuite {
+  test("orElse") {
+    val a: UriTemplateClassifier =
+      uri => Option.when(uri.path == Uri.Path.Root / "a")("/a")
+    val b: UriTemplateClassifier =
+      uri => Option.when(uri.path == Uri.Path.Root / "b")("/b")
+    val classifier = a.orElse(b)
+    def check(uri: Uri, expected: Option[String]): Unit =
+      assertEquals(classifier.classify(uri), expected)
+
+    check(uri"https://example.com/a", Some("/a"))
+    check(uri"https://example.com/b", Some("/b"))
+    check(uri"https://example.com/c", None)
+  }
+}

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/AttributeProvider.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/AttributeProvider.scala
@@ -21,6 +21,8 @@ package trace.server
 import org.typelevel.ci.CIString
 import org.typelevel.otel4s.Attributes
 
+import scala.collection.immutable.ArraySeq
+
 /** Provides attributes for spans using requests and responses.
   *
   * It is RECOMMENDED that callers pass `Request`s and `Response`s that have
@@ -63,40 +65,50 @@ trait AttributeProvider { self =>
   /** @return an `AttributeProvider` that provides the attributes from this and
     *         another `AttributeProvider`
     */
-  def and(that: AttributeProvider): AttributeProvider =
-    new AttributeProvider {
+  def and(that: AttributeProvider): AttributeProvider = that match {
+    case AttributeProvider.Multi(providers) =>
+      AttributeProvider.Multi(this +: providers)
+    case _ => AttributeProvider.Multi(ArraySeq(this, that))
+  }
+}
+
+object AttributeProvider {
+
+  private[server] trait Multi extends AttributeProvider {
+    protected def providers: Seq[AttributeProvider]
+  }
+
+  private[server] object Multi {
+    private[this] final class Impl(protected val providers: Seq[AttributeProvider]) extends Multi {
       def requestAttributes[F[_]](
           request: Request[F],
           routeClassifier: RouteClassifier,
           redactor: PathAndQueryRedactor,
           headersAllowedAsAttributes: Set[CIString],
       ): Attributes =
-        self.requestAttributes(
-          request,
-          routeClassifier,
-          redactor,
-          headersAllowedAsAttributes,
-        ) ++
-          that.requestAttributes(
-            request,
-            routeClassifier,
-            redactor,
-            headersAllowedAsAttributes,
-          )
-
+        providers.foldLeft(Attributes.empty)(
+          _ ++ _.requestAttributes(request, routeClassifier, redactor, headersAllowedAsAttributes)
+        )
       def responseAttributes[F[_]](
           response: Response[F],
           headersAllowedAsAttributes: Set[CIString],
       ): Attributes =
-        self.responseAttributes(response, headersAllowedAsAttributes) ++
-          that.responseAttributes(response, headersAllowedAsAttributes)
-
+        providers.foldLeft(Attributes.empty)(
+          _ ++ _.responseAttributes(response, headersAllowedAsAttributes)
+        )
       def exceptionAttributes(cause: Throwable): Attributes =
-        self.exceptionAttributes(cause) ++ that.exceptionAttributes(cause)
-    }
-}
+        providers.foldLeft(Attributes.empty)(_ ++ _.exceptionAttributes(cause))
 
-object AttributeProvider {
+      override def and(that: AttributeProvider): AttributeProvider = that match {
+        case Multi(ps) => new Impl(providers ++ ps)
+        case _ => new Impl(providers :+ that)
+      }
+    }
+
+    def apply(providers: Seq[AttributeProvider]): Multi = new Impl(providers)
+
+    def unapply(multi: Multi): Some[Seq[AttributeProvider]] = Some(multi.providers)
+  }
 
   /** Provides an `Attribute` containing this middleware's version. */
   val middlewareVersion: AttributeProvider =
@@ -105,11 +117,11 @@ object AttributeProvider {
           request: Request[F],
           routeClassifier: RouteClassifier,
           redactor: PathAndQueryRedactor,
-          headersAllowedAsAttributes: Set[AuthScheme],
+          headersAllowedAsAttributes: Set[CIString],
       ): Attributes = Attributes(TypedAttributes.middlewareVersion)
       def responseAttributes[F[_]](
           response: Response[F],
-          headersAllowedAsAttributes: Set[AuthScheme],
+          headersAllowedAsAttributes: Set[CIString],
       ): Attributes = Attributes.empty
       def exceptionAttributes(cause: Throwable): Attributes =
         Attributes.empty

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareBuilder.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareBuilder.scala
@@ -96,6 +96,7 @@ class ServerMiddlewareBuilder[F[_]: TracerProvider: MonadCancelThrow] private (
       tracerF <- TracerProvider[F]
         .tracer("org.http4s.otel4s.middleware.server")
         .withVersion(org.http4s.otel4s.middleware.BuildInfo.version)
+        .withSchemaUrl("https://opentelemetry.io/schemas/1.29.0")
         .get
     } yield Kleisli { (req: Request[F]) =>
       if (

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/SpanDataProvider.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/SpanDataProvider.scala
@@ -23,6 +23,8 @@ import org.typelevel.ci.CIString
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.Attributes
 
+import scala.collection.immutable.ArraySeq
+
 /** Provides a name and attributes for spans using requests and responses.
   *
   * It is RECOMMENDED that callers pass `Request`s and `Response`s that have
@@ -94,65 +96,72 @@ trait SpanDataProvider extends AttributeProvider { self =>
       headersAllowedAsAttributes,
     )
 
-  /** Returns an `AttributeProvider` that provides the attributes from this and
-    * another `AttributeProvider`.
+  /** Returns a `SpanDataProvider` that provides the attributes from this and
+    * another [[`AttributeProvider`]].
     *
-    * If `that` is a `SpanAndAttributeProvider`, it will not be used to provide
+    * If `that` is a `SpanDataProvider`, it will not be used to provide
     * span names.
     */
-  override def and(that: AttributeProvider): SpanDataProvider =
-    new SpanDataProvider {
-      type Shared = self.Shared
-
-      def processSharedData[F[_]](
-          request: Request[F],
-          routeClassifier: RouteClassifier,
-          redactor: PathAndQueryRedactor,
-      ): Shared =
-        self.processSharedData(request, routeClassifier, redactor)
-
-      def spanName[F[_]](
-          request: Request[F],
-          routeClassifier: RouteClassifier,
-          redactor: PathAndQueryRedactor,
-          sharedProcessedData: Shared,
-      ): String =
-        self.spanName(request, routeClassifier, redactor, sharedProcessedData)
-
-      def requestAttributes[F[_]](
-          request: Request[F],
-          routeClassifier: RouteClassifier,
-          redactor: PathAndQueryRedactor,
-          sharedProcessedData: Shared,
-          headersAllowedAsAttributes: Set[CIString],
-      ): Attributes =
-        self.requestAttributes(
-          request,
-          routeClassifier,
-          redactor,
-          sharedProcessedData,
-          headersAllowedAsAttributes,
-        ) ++
-          that.requestAttributes(
-            request,
-            routeClassifier,
-            redactor,
-            headersAllowedAsAttributes,
-          )
-
-      def responseAttributes[F[_]](
-          response: Response[F],
-          headersAllowedAsAttributes: Set[CIString],
-      ): Attributes =
-        self.responseAttributes(response, headersAllowedAsAttributes) ++
-          that.responseAttributes(response, headersAllowedAsAttributes)
-
-      def exceptionAttributes(cause: Throwable): Attributes =
-        self.exceptionAttributes(cause) ++ that.exceptionAttributes(cause)
-    }
+  override def and(that: AttributeProvider): SpanDataProvider = that match {
+    case AttributeProvider.Multi(providers) =>
+      SpanDataProvider.Multi(this, providers)
+    case _ => SpanDataProvider.Multi(this, ArraySeq(that))
+  }
 }
 
 object SpanDataProvider {
+
+  // it is crucial that `primary` is never an instance of `Multi`
+  private final case class Multi(primary: SpanDataProvider, others: Seq[AttributeProvider])
+      extends SpanDataProvider
+      with AttributeProvider.Multi {
+    type Shared = primary.Shared
+    protected def providers: Seq[AttributeProvider] = primary +: others
+    def processSharedData[F[_]](
+        request: Request[F],
+        routeClassifier: RouteClassifier,
+        redactor: PathAndQueryRedactor,
+    ): Shared = primary.processSharedData(request, routeClassifier, redactor)
+    def spanName[F[_]](
+        request: Request[F],
+        routeClassifier: RouteClassifier,
+        redactor: PathAndQueryRedactor,
+        sharedProcessedData: Shared,
+    ): String = primary.spanName(request, routeClassifier, redactor, sharedProcessedData)
+    def requestAttributes[F[_]](
+        request: Request[F],
+        routeClassifier: RouteClassifier,
+        redactor: PathAndQueryRedactor,
+        sharedProcessedData: Shared,
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes =
+      others.foldLeft(
+        primary
+          .requestAttributes(
+            request,
+            routeClassifier,
+            redactor,
+            sharedProcessedData,
+            headersAllowedAsAttributes,
+          )
+      )(_ ++ _.requestAttributes(request, routeClassifier, redactor, headersAllowedAsAttributes))
+    def responseAttributes[F[_]](
+        response: Response[F],
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes =
+      others.foldLeft(primary.responseAttributes(response, headersAllowedAsAttributes))(
+        _ ++ _.responseAttributes(response, headersAllowedAsAttributes)
+      )
+    def exceptionAttributes(cause: Throwable): Attributes =
+      others.foldLeft(primary.exceptionAttributes(cause))(
+        _ ++ _.exceptionAttributes(cause)
+      )
+
+    override def and(that: AttributeProvider): SpanDataProvider = that match {
+      case AttributeProvider.Multi(providers) => copy(others = others ++ providers)
+      case _ => copy(others = others :+ that)
+    }
+  }
 
   /** A `SpanAndAttributeProvider` following OpenTelemetry semantic conventions. */
   val openTelemetry: SpanDataProvider = {

--- a/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/RouteClassifierTest.scala
+++ b/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/RouteClassifierTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package otel4s.middleware.trace.server
+
+import cats.effect.IO
+import munit.FunSuite
+import org.http4s.dsl.Http4sDsl
+import org.http4s.syntax.literals._
+
+class RouteClassifierTest extends FunSuite {
+  test("of") {
+    val classifier = locally {
+      val http4sDsl = Http4sDsl[IO]
+      import http4sDsl._
+      RouteClassifier.of[IO] {
+        case POST -> Root / "users" => "/users"
+        case (GET | PUT) -> Root / "users" / UUIDVar(_) / "profile" =>
+          "/users/{userId}/profile"
+        case (HEAD | DELETE) -> Root / "users" / UUIDVar(_) =>
+          "/users/{userId}"
+      }
+    }
+    def check(method: Method, uri: Uri, expected: Option[String]): Unit =
+      assertEquals(classifier.classify(Request(method, uri).requestPrelude), expected)
+
+    check(Method.POST, uri"/users", Some("/users"))
+    check(Method.POST, uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87", None)
+    check(Method.POST, uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87/profile", None)
+    check(
+      Method.GET,
+      uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87/profile?foo=bar",
+      Some("/users/{userId}/profile"),
+    )
+    check(Method.GET, uri"/users/not-a-uuid/profile", None)
+    check(Method.GET, uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87", None)
+    check(
+      Method.PUT,
+      uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87/profile",
+      Some("/users/{userId}/profile"),
+    )
+    check(Method.PUT, uri"/users/not-a-uuid/profile", None)
+    check(Method.PUT, uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87", None)
+    check(Method.HEAD, uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87", Some("/users/{userId}"))
+    check(Method.HEAD, uri"/users/not-a-uuid", None)
+    check(Method.HEAD, uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87/profile", None)
+    check(Method.HEAD, uri"/users", None)
+    check(Method.DELETE, uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87", Some("/users/{userId}"))
+    check(Method.DELETE, uri"/users/not-a-uuid", None)
+    check(Method.DELETE, uri"/users/295472d0-ef9e-48a7-84bd-100a4672ff87/profile", None)
+    check(Method.DELETE, uri"/users", None)
+  }
+
+  test("orElse") {
+    val a = locally {
+      val http4sDsl = Http4sDsl[IO]
+      import http4sDsl._
+      RouteClassifier.of[IO] { case POST -> Root / "test" =>
+        "/test"
+      }
+    }
+    val b = locally {
+      val http4sDsl = Http4sDsl[IO]
+      import http4sDsl._
+      RouteClassifier.of[IO] { case GET -> Root / "test" =>
+        "/test"
+      }
+    }
+    val classifier = a.orElse(b)
+    def check(method: Method, uri: Uri, expected: Option[String]): Unit =
+      assertEquals(classifier.classify(Request(method, uri).requestPrelude), expected)
+
+    check(Method.POST, uri"/test", Some("/test"))
+    check(Method.GET, uri"/test", Some("/test"))
+    check(Method.DELETE, uri"/test", None)
+    check(Method.POST, uri"/other", None)
+    check(Method.GET, uri"/other", None)
+  }
+}

--- a/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTest.scala
+++ b/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTest.scala
@@ -40,8 +40,8 @@ import org.typelevel.otel4s.trace.TracerProvider
 import scala.concurrent.duration.Duration
 import scala.util.control.NoStackTrace
 
-class ServerMiddlewareTests extends CatsEffectSuite {
-  import ServerMiddlewareTests.NoopRedactor
+class ServerMiddlewareTest extends CatsEffectSuite {
+  import ServerMiddlewareTest.NoopRedactor
 
   private val spanLimits = SpanLimits.default
 
@@ -251,6 +251,6 @@ class ServerMiddlewareTests extends CatsEffectSuite {
   }
 }
 
-object ServerMiddlewareTests {
+object ServerMiddlewareTest {
   object NoopRedactor extends PathRedactor.NeverRedact with QueryRedactor.NeverRedact
 }

--- a/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/SpanDataProviderTest.scala
+++ b/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/SpanDataProviderTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package otel4s.middleware.trace.server
+
+import munit.FunSuite
+import munit.Location
+import org.typelevel.ci.CIString
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.Attributes
+
+class SpanDataProviderTest extends FunSuite {
+  import SpanDataProviderTest._
+
+  private[this] def check(
+      output: Attributes,
+      keys: Seq[String],
+      last: String,
+  )(implicit loc: Location): Unit =
+    assertEquals(
+      output,
+      keys.map(k => Attribute(s"test.key.$k", 1L)).to(Attributes) + Attribute("test.last", last),
+    )
+
+  test("and") {
+    val a = new SimpleAttributeProvider("a")
+    val b = new SimpleAttributeProvider("b")
+    val c = new SimpleSpanDataProvider("c")
+    val d = new SimpleSpanDataProvider("d")
+
+    val cabd = c.and(a.and(b).and(d))
+    assertEquals(cabd.spanName(null, null, null, null.asInstanceOf[cabd.Shared]), "c")
+    check(cabd.requestAttributes(null, null, null, null), Seq("a", "b", "c", "d"), "d")
+    check(cabd.responseAttributes(null, null), Seq("a", "b", "c", "d"), "d")
+    check(cabd.exceptionAttributes(null), Seq("a", "b", "c", "d"), "d")
+
+    val db = d.and(b)
+    assertEquals(db.spanName(null, null, null, null.asInstanceOf[db.Shared]), "d")
+    check(db.requestAttributes(null, null, null, null), Seq("b", "d"), "b")
+    check(db.responseAttributes(null, null), Seq("b", "d"), "b")
+    check(db.exceptionAttributes(null), Seq("b", "d"), "b")
+  }
+}
+
+object SpanDataProviderTest {
+  private[this] def attr(name: String): Attributes =
+    Attributes(Attribute(s"test.key.$name", 1L), Attribute("test.last", name))
+
+  private final class SimpleAttributeProvider(name: String) extends AttributeProvider {
+    def requestAttributes[F[_]](
+        request: Request[F],
+        routeClassifier: RouteClassifier,
+        redactor: PathAndQueryRedactor,
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes = attr(name)
+    def responseAttributes[F[_]](
+        response: Response[F],
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes = attr(name)
+    def exceptionAttributes(cause: Throwable): Attributes =
+      attr(name)
+  }
+
+  private final class SimpleSpanDataProvider(name: String) extends SpanDataProvider {
+    type Shared = Null
+    def processSharedData[F[_]](
+        request: Request[F],
+        routeClassifier: RouteClassifier,
+        redactor: PathAndQueryRedactor,
+    ): Null = null
+    def spanName[F[_]](
+        request: Request[F],
+        routeClassifier: RouteClassifier,
+        redactor: PathAndQueryRedactor,
+        sharedProcessedData: Null,
+    ): String = name
+    def requestAttributes[F[_]](
+        request: Request[F],
+        routeClassifier: RouteClassifier,
+        redactor: PathAndQueryRedactor,
+        sharedProcessedData: Null,
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes = attr(name)
+    def responseAttributes[F[_]](
+        response: Response[F],
+        headersAllowedAsAttributes: Set[CIString],
+    ): Attributes = attr(name)
+    def exceptionAttributes(cause: Throwable): Attributes =
+      attr(name)
+  }
+}


### PR DESCRIPTION
Add `RouteClassifier#orElse` and `UriTemplateClassifier#orElse` for
combining classifiers.

Add schema to `Tracer` creation in middlewares.

Minimise intermidiate collections created by `AttributeProvider`
and `SpanDataProvider` when combined, and add tests for correct
behaviour when combined.