### PR TITLE
Add `Http4sDsl` support to `UriTemplateClassifier`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,8 @@ lazy val `core-client` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := s"$baseName-core-client",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "otel4s-semconv-experimental" % otel4sV
+      "org.typelevel" %%% "otel4s-semconv-experimental" % otel4sV,
+      "org.http4s" %%% "http4s-dsl" % http4sV % Test,
     ),
   )
 

--- a/core/client/src/main/scala/org/http4s/otel4s/middleware/client/TypedClientAttributes.scala
+++ b/core/client/src/main/scala/org/http4s/otel4s/middleware/client/TypedClientAttributes.scala
@@ -54,7 +54,7 @@ private[middleware] trait TypedClientAttributes extends TypedAttributes {
       .map(_.value.toLong)
       .orElse(url.port.map(_.toLong))
       .orElse(portFromScheme(url.scheme))
-      .map(ServerAttributes.ServerPort.apply)
+      .map(ServerAttributes.ServerPort(_))
 
   /** @return the `url.scheme` `Attribute` */
   final def urlScheme(scheme: Uri.Scheme): Attribute[String] =
@@ -84,9 +84,7 @@ object TypedClientAttributes extends TypedClientAttributes {
 
     /** @return the `url.template` `Attribute` */
     final def urlTemplate(url: Uri, classifier: UriTemplateClassifier): Option[Attribute[String]] =
-      classifier
-        .classify(url)
-        .map(UrlExperimentalAttributes.UrlTemplate(_))
+      UrlExperimentalAttributes.UrlTemplate.maybe(classifier.classify(url))
   }
 
   private object _Experimental extends Experimental

--- a/core/client/src/main/scala/org/http4s/otel4s/middleware/client/UriTemplateClassifier.scala
+++ b/core/client/src/main/scala/org/http4s/otel4s/middleware/client/UriTemplateClassifier.scala
@@ -65,4 +65,24 @@ object UriTemplateClassifier {
 
   /** A classifier that does not classify any URI templates. */
   val indeterminate: UriTemplateClassifier = _ => None
+
+  /** Somewhat similar to `HttpRoutes.of` for use with `Http4sDsl`.
+    *
+    * @example
+    * {{{
+    * val http4sDsl = Http4sDsl[F]
+    * import http4sDsl._
+    * object Limit extends QueryParamDecoderMatcher[Int]("limit")
+    * UriTemplateClassifier.matchingPathAndQuery {
+    *   case (Root / "users" / UUIDVar(_) / "posts", Limit(_)) =>
+    *     "/users/{userId}/posts?limit={count}"
+    * }
+    * }}}
+    */
+  def matchingPathAndQuery(
+      pf: PartialFunction[(Uri.Path, Map[String, collection.Seq[String]]), String]
+  ): UriTemplateClassifier = {
+    val lifted = pf.lift
+    url => lifted(url.path -> url.query.multiParams)
+  }
 }

--- a/core/server/src/main/scala/org/http4s/otel4s/middleware/server/RouteClassifier.scala
+++ b/core/server/src/main/scala/org/http4s/otel4s/middleware/server/RouteClassifier.scala
@@ -72,6 +72,17 @@ object RouteClassifier {
   /** Mirrors `HttpRoutes.of` for use with `Http4sDsl`. The `Request` passed to
     * the provided `PartialFunction` will only be populated by the values from
     * a `RequestPrelude`.
+    *
+    * @example
+    * {{{
+    * val http4sDsl = Http4sDsl[F]
+    * import http4sDsl._
+    * object Limit extends QueryParamDecoderMatcher[Int]("limit")
+    * RouteClassifier.of[F] {
+    *   case GET -> Root / "users" / UUIDVar(_) / "posts" :? Limit(_) =>
+    *     "/users/{userId}/posts?limit={count}"
+    * }
+    * }}}
     */
   def of[F[_]](pf: PartialFunction[Request[F], String]): RouteClassifier = {
     val lifted = pf.lift

--- a/core/server/src/main/scala/org/http4s/otel4s/middleware/server/TypedServerAttributes.scala
+++ b/core/server/src/main/scala/org/http4s/otel4s/middleware/server/TypedServerAttributes.scala
@@ -34,7 +34,7 @@ private[middleware] trait TypedServerAttributes extends TypedAttributes {
       request: RequestPrelude,
       classifier: RouteClassifier,
   ): Option[Attribute[String]] =
-    classifier.classify(request).map(HttpAttributes.HttpRoute.apply)
+    HttpAttributes.HttpRoute.maybe(classifier.classify(request))
 
   /** @return the `http.route` `Attribute` */
   final def httpRoute[F[_]](

--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/TypedClientTraceAttributes.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/TypedClientTraceAttributes.scala
@@ -39,7 +39,7 @@ object TypedClientTraceAttributes extends TypedClientAttributes with TypedTraceA
       .collect {
         case c if c > 1 => c - 1L
       }
-      .map(HttpAttributes.HttpRequestResendCount.apply)
+      .map(HttpAttributes.HttpRequestResendCount(_))
 
   /** @return the `url.full` `Attribute` containing the URL after redacting it
     *         with the provided [[`UriRedactor`]].


### PR DESCRIPTION
Add `UriTemplateClassifier.matchingPathAndQuery` for creating instances utilising `Http4sDsl`.

Tidy up `Typed<Category>Attributes` implementations slightly.