### PR TITLE
Optimise combining "empty" instances

### DIFF
--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/SpanDataProvider.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/SpanDataProvider.scala
@@ -73,6 +73,7 @@ trait SpanDataProvider extends AttributeProvider {
     * span names.
     */
   override def and(that: AttributeProvider): SpanDataProvider = that match {
+    case AttributeProvider.Empty => this
     case AttributeProvider.Multi(providers) =>
       SpanDataProvider.Multi(this, providers)
     case _ => SpanDataProvider.Multi(this, ArraySeq(that))
@@ -101,6 +102,7 @@ object SpanDataProvider {
       others.foldLeft(primary.exceptionAttributes(cause))(_ ++ _.exceptionAttributes(cause))
 
     override def and(that: AttributeProvider): SpanDataProvider = that match {
+      case AttributeProvider.Empty => this
       case AttributeProvider.Multi(providers) => copy(others = others ++ providers)
       case _ => copy(others = others :+ that)
     }

--- a/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/AttributeProviderTest.scala
+++ b/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/AttributeProviderTest.scala
@@ -47,6 +47,10 @@ class AttributeProviderTest extends FunSuite {
     assert(p.responseAttributes(null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
     assert(p.requestAttributes(null) eq p.requestAttributes(null))
+
+    val e = AttributeProvider.const()
+    assert(p.and(e) eq p)
+    assert(e.and(p) eq p)
   }
 
   test("middlewareVersion") {


### PR DESCRIPTION
Optimise combining "empty" `AttributeProvider`, `SpanDataProvider`, `RouteClassifier` and `UriTemplateClassifier` instances.

Add additional/missing tests.