### PR TITLE
Update `otel4s` to version `0.12.0`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val http4sV = "0.23.30"
 val munitV = "1.0.0"
 val munitCatsEffectV = "2.0.0"
 val openTelemetryV = "1.48.0"
-val otel4sV = "0.11.2"
+val otel4sV = "0.12.0"
 val slf4jV = "1.7.36"
 
 val baseName = "http4s-otel4s-middleware"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.18.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.18.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareTest.scala
+++ b/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareTest.scala
@@ -248,7 +248,6 @@ class ClientMiddlewareTest extends CatsEffectSuite {
                       spanLimits.maxNumberOfAttributes,
                       spanLimits.maxAttributeValueLength,
                     ),
-                  escaped = false,
                 )
               )
 
@@ -349,7 +348,6 @@ class ClientMiddlewareTest extends CatsEffectSuite {
                       spanLimits.maxNumberOfAttributes,
                       spanLimits.maxAttributeValueLength,
                     ),
-                  escaped = false,
                 )
               )
 

--- a/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTest.scala
+++ b/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTest.scala
@@ -148,7 +148,6 @@ class ServerMiddlewareTest extends CatsEffectSuite {
                         spanLimits.maxNumberOfAttributes,
                         spanLimits.maxAttributeValueLength,
                       ),
-                    escaped = false,
                   )
                 )
 


### PR DESCRIPTION
- Update Scala JS to get around compilation issue 
- Fix compilation issue with otel4s `0.12.0`