### PR TITLE
Remove `User-Agent` from default allowed headers

### DIFF
--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/redact/HeaderRedactor.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/redact/HeaderRedactor.scala
@@ -167,7 +167,6 @@ object HeaderRedactor {
     "Trailer",
     "Transfer-Encoding",
     "Upgrade",
-    "User-Agent",
     "Vary",
     "Via",
     "Viewport-Width",


### PR DESCRIPTION
Remove `User-Agent` from default allowed headers, as it has its own attribute and is not recommended to have as a duplicate.