### PR TITLE
Add reverse propagation to `ServerMiddleware`

### DIFF
--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
@@ -144,7 +144,8 @@ object ClientMiddleware {
       )
 
     /** Sets a filter that determines whether each request should propagate
-      * tracing and other context information to the server.
+      * tracing and other context information to the server (default: always
+      * enabled).
       */
     def withPerRequestPropagationFilter(
         perRequestPropagationFilter: PerRequestFilter
@@ -152,7 +153,7 @@ object ClientMiddleware {
       copy(perRequestPropagationFilter = perRequestPropagationFilter)
 
     /** Sets a filter that determines whether each request and its response
-      * should be traced.
+      * should be traced (default: always enabled).
       */
     def withPerRequestTracingFilter(
         perRequestTracingFilter: PerRequestFilter


### PR DESCRIPTION
Add configureable `perRequestReversePropagationFilter` to
`ServerMiddleware` to allow sending trace and context information
back to the requesting client, primarily for debugging.

~~built on top of #224 to avoid conflicts; ignore 06892ff9833a0a39c64f1ebc4024aa2d0e39e3ab when reviewing~~

- [x] cherry-pick on top of main once the aforementioned PR gets merged