### PR TITLE
0.10: fix streaming bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,30 +24,29 @@ concurrency:
 
 jobs:
   build:
-    name: Build and Test
+    name: Test
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         scala: [2.13, 3]
         java: [temurin@17]
         project: [http4s-otel4s-middlewareJVM, http4s-otel4s-middlewareJS, http4s-otel4s-middlewareNative]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
-      - name: Install sbt
-        if: contains(runner.os, 'macos')
-        run: brew install sbt
-
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -61,7 +60,7 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: scalaJSLink
@@ -76,11 +75,11 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Check scalafix lints
@@ -101,7 +100,7 @@ jobs:
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
           path: targets.tar
@@ -112,23 +111,22 @@ jobs:
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install sbt
-        if: contains(runner.os, 'macos')
-        run: brew install sbt
-
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -139,7 +137,7 @@ jobs:
         run: sbt +update
 
       - name: Download target directories (2.13, http4s-otel4s-middlewareJVM)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-http4s-otel4s-middlewareJVM
 
@@ -149,7 +147,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13, http4s-otel4s-middlewareJS)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-http4s-otel4s-middlewareJS
 
@@ -159,7 +157,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13, http4s-otel4s-middlewareNative)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-http4s-otel4s-middlewareNative
 
@@ -169,7 +167,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, http4s-otel4s-middlewareJVM)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4s-otel4s-middlewareJVM
 
@@ -179,7 +177,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, http4s-otel4s-middlewareJS)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4s-otel4s-middlewareJS
 
@@ -189,7 +187,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, http4s-otel4s-middlewareNative)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4s-otel4s-middlewareNative
 
@@ -227,23 +225,22 @@ jobs:
     if: github.event.repository.fork == false && github.event_name != 'pull_request'
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install sbt
-        if: contains(runner.os, 'macos')
-        run: brew install sbt
-
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -263,20 +260,20 @@ jobs:
     name: Validate Steward Config
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        java: [temurin@11]
+        os: [ubuntu-22.04]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (fast)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - uses: coursier/setup-action@v1
         with:
@@ -288,23 +285,22 @@ jobs:
     name: Generate Site
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install sbt
-        if: contains(runner.os, 'macos')
-        run: brew install sbt
-
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.3
+sbt.version=1.12.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.17.3")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "2.0.7")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
@@ -19,12 +19,14 @@ package otel4s.middleware
 package trace
 package server
 
+import cats.Applicative
 import cats.data.Kleisli
 import cats.effect.kernel.MonadCancelThrow
 import cats.effect.kernel.Outcome
-import cats.effect.syntax.monadCancel._
-import cats.syntax.applicative._
-import cats.syntax.flatMap._
+import cats.effect.kernel.Resource
+import cats.effect.syntax.all._
+import cats.syntax.all._
+import cats.~>
 import org.http4s.Status.ServerError
 import org.http4s.headers.Host
 import org.http4s.headers.`User-Agent`
@@ -180,34 +182,67 @@ object ServerMiddleware {
               urlRedactor,
             ) ++ additionalRequestAttributes(reqPrelude)
           MonadCancelThrow[G].uncancelable { poll =>
-            val tracerG = Tracer[F].mapK[G]
-            tracerG.joinOrRoot(req.headers) {
-              tracerG
-                .spanBuilder(serverSpanName(reqPrelude))
-                .withSpanKind(SpanKind.Server)
-                .addAttributes(init)
-                .build
-                .use { span =>
-                  poll(f.run(req))
-                    .guaranteeCase {
-                      case Outcome.Succeeded(fa) =>
-                        fa.flatMap { resp =>
-                          val out =
-                            response(
-                              resp,
-                              allowedResponseHeaders,
-                            ) ++ additionalResponseAttributes(resp.responsePrelude)
-
-                          span.addAttributes(out) >> span
-                            .setStatus(StatusCode.Error)
-                            .unlessA(resp.status.isSuccess)
-                        }
-                      case Outcome.Errored(e) =>
-                        span.addAttributes(TypedAttributes.errorType(e))
-                      case Outcome.Canceled() =>
-                        MonadCancelThrow[G].unit
+            kt.liftK(
+              Tracer[F].joinOrRoot(req.headers) {
+                Tracer[F]
+                  .spanBuilder(serverSpanName(reqPrelude))
+                  .withSpanKind(SpanKind.Server)
+                  .addAttributes(init)
+                  .build
+                  .resource
+                  .allocated
+              }
+            ).flatMap { case (res, release) =>
+              val span = res.span
+              Tracer[F].mapK[G].childScope(span.context) {
+                poll(f.run(req))
+                  .map { resp =>
+                    val out =
+                      response(
+                        resp,
+                        allowedResponseHeaders,
+                      ) ++ additionalResponseAttributes(resp.responsePrelude)
+                    val propagateScope = new (F ~> F) {
+                      def apply[A](fa: F[A]): F[A] =
+                        Tracer[F].childScope(span.context)(fa)
                     }
-                }
+                    resp.pipeBodyThrough {
+                      _.translate(propagateScope)
+                        .onFinalizeCaseWeak {
+                          case Resource.ExitCase.Succeeded =>
+                            span.addAttributes(out) >>
+                              span.setStatus(StatusCode.Error).unlessA(resp.status.isSuccess) >>
+                              release
+                          case Resource.ExitCase.Errored(e) =>
+                            span.addAttributes(out) >>
+                              span.recordException(e) >>
+                              span.addAttributes(TypedAttributes.errorType(e)) >>
+                              span.setStatus(StatusCode.Error) >>
+                              release
+                          case Resource.ExitCase.Canceled =>
+                            span.addAttributes(out) >>
+                              span.setStatus(StatusCode.Error, "canceled") >>
+                              release
+                        }
+                    }
+                  }
+                  .guaranteeCase {
+                    case Outcome.Succeeded(_) =>
+                      Applicative[G].unit
+                    case Outcome.Errored(e) =>
+                      kt.liftK(
+                        span.recordException(e) >>
+                          span.addAttributes(TypedAttributes.errorType(e)) >>
+                          span.setStatus(StatusCode.Error) >>
+                          release
+                      )
+                    case Outcome.Canceled() =>
+                      kt.liftK(
+                        span.setStatus(StatusCode.Error, "canceled") >>
+                          release
+                      )
+                  }
+              }
             }
           }
         }

--- a/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTests.scala
+++ b/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTests.scala
@@ -34,7 +34,7 @@ import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.StatusCode
 import org.typelevel.otel4s.trace.Tracer
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 class ServerMiddlewareTests extends CatsEffectSuite {
@@ -62,7 +62,7 @@ class ServerMiddlewareTests extends CatsEffectSuite {
             val request =
               Request[IO](Method.GET, uri"http://localhost/?#")
                 .withHeaders(headers)
-            tracedServer.run(request)
+            tracedServer.run(request).flatMap(_.body.compile.drain)
           }
           spans <- testkit.finishedSpans
         } yield {
@@ -129,7 +129,7 @@ class ServerMiddlewareTests extends CatsEffectSuite {
             )
 
             for {
-              _ <- tracedServer.run(request).attempt
+              _ <- tracedServer.run(request).flatMap(_.body.compile.drain).attempt
               spans <- testkit.finishedSpans
             } yield {
               assertEquals(spans.map(_.attributes.elements), List(attributes))
@@ -165,7 +165,7 @@ class ServerMiddlewareTests extends CatsEffectSuite {
             )
 
             for {
-              _ <- tracedServer.run(request).attempt
+              _ <- tracedServer.run(request).flatMap(_.body.compile.drain).attempt
               spans <- testkit.finishedSpans
             } yield {
               assertEquals(spans.map(_.attributes.elements), List(attributes))
@@ -199,7 +199,7 @@ class ServerMiddlewareTests extends CatsEffectSuite {
             )
 
             for {
-              f <- tracedServer.run(request).void.start
+              f <- tracedServer.run(request).flatMap(_.body.compile.drain).start
               _ <- f.joinWithUnit
               spans <- testkit.finishedSpans
             } yield {
@@ -212,4 +212,131 @@ class ServerMiddlewareTests extends CatsEffectSuite {
     }
   }
 
+  test("propagate span context to response body streaming") {
+    TracesTestkit
+      .inMemory[IO]()
+      .use { testkit =>
+        testkit.tracerProvider.get("tracer").flatMap { implicit tracer =>
+          val body = fs2.Stream.eval(
+            Tracer[IO].span("body-span").use(_ => IO.pure('.'.toByte))
+          )
+
+          val tracedServer = ServerMiddleware
+            .default[IO]
+            .buildHttpApp(HttpApp[IO](_ => IO.pure(Response[IO](Status.Ok).withBodyStream(body))))
+
+          val request = Request[IO](Method.GET, uri"http://localhost/")
+
+          for {
+            res <- tracedServer.run(request)
+            _ <- res.body.compile.drain
+            spans <- testkit.finishedSpans
+          } yield {
+            assertEquals(spans.length, 2)
+            val serverSpan = spans.find(_.name == "Http Server - GET")
+            val bodySpan = spans.find(_.name == "body-span")
+
+            assert(serverSpan.isDefined, "server span not found")
+            assert(bodySpan.isDefined, "body span not found")
+
+            assertEquals(
+              bodySpan.get.parentSpanContext.map(_.spanId),
+              Some(serverSpan.get.spanContext.spanId),
+            )
+          }
+        }
+      }
+  }
+
+  test("record an exception thrown during response body streaming") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          testkit.tracerProvider.get("tracer").flatMap { implicit tracer =>
+            val error = new RuntimeException("stream crash") with NoStackTrace {}
+            val body = fs2.Stream.raiseError[IO](error)
+
+            val tracedServer = ServerMiddleware
+              .default[IO]
+              .buildHttpApp(HttpApp[IO](_ => IO.pure(Response[IO](Status.Ok).withBodyStream(body))))
+
+            val request = Request[IO](Method.GET, uri"http://localhost/")
+
+            val events = Vector(
+              EventData.fromException(
+                Duration.Zero,
+                error,
+                LimitedData
+                  .attributes(spanLimits.maxNumberOfAttributes, spanLimits.maxAttributeValueLength),
+                escaped = false,
+              )
+            )
+
+            val status = StatusData(StatusCode.Error)
+
+            val attributes = Attributes(
+              Attribute("http.request.method", "GET"),
+              Attribute("url.path", "/"),
+              Attribute("url.full", "http://localhost/"),
+              Attribute("url.scheme", "http"),
+              Attribute("server.address", "localhost"),
+              Attribute("http.response.status_code", 200L),
+              Attribute("error.type", error.getClass.getName),
+            )
+
+            for {
+              res <- tracedServer.run(request)
+              _ <- res.body.compile.drain.attempt
+              spans <- testkit.finishedSpans
+            } yield {
+              assertEquals(spans.map(_.attributes.elements), List(attributes))
+              assertEquals(spans.map(_.events.elements), List(events))
+              assertEquals(spans.map(_.status), List(status))
+            }
+          }
+        }
+    }
+  }
+
+  test("record cancellation during response body streaming") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          testkit.tracerProvider.get("tracer").flatMap { implicit tracer =>
+            val body = fs2.Stream.eval(IO.never[Byte])
+
+            val tracedServer = ServerMiddleware
+              .default[IO]
+              .buildHttpApp(HttpApp[IO](_ => IO.pure(Response[IO](Status.Ok).withBodyStream(body))))
+
+            val request = Request[IO](Method.GET, uri"http://localhost/")
+
+            val status = StatusData(StatusCode.Error, "canceled")
+
+            val attributes = Attributes(
+              Attribute("http.request.method", "GET"),
+              Attribute("url.path", "/"),
+              Attribute("url.full", "http://localhost/"),
+              Attribute("url.scheme", "http"),
+              Attribute("server.address", "localhost"),
+              Attribute("http.response.status_code", 200L),
+            )
+
+            for {
+              res <- tracedServer.run(request)
+              f <- res.body.compile.drain.start
+              _ <- IO.sleep(10.millis)
+              _ <- f.cancel
+              spans <- testkit.finishedSpans
+            } yield {
+              assertEquals(spans.map(_.attributes.elements), List(attributes))
+              assertEquals(spans.flatMap(_.events.elements), Nil)
+              assertEquals(spans.map(_.status), List(status))
+            }
+          }
+        }
+    }
+  }
 }


### PR DESCRIPTION
- Propagate response span context into the streaming body
- Handle errors and cancellation that occur compiling the body

This depends on the backend draining the stream, which both Blaze and Ember should be doing.

Could not figure out how to reuse the logic from `BracketRequestResponse`, but it's the same idea.
