### PR TITLE
Add ErrorClassifier for customizable HTTP error status classification

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,13 @@ lazy val `trace-client` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.http4s" %%% "http4s-client" % http4sV,
       "org.typelevel" %%% "otel4s-core-trace" % otel4sV,
     ),
+    mimaBinaryIssueFilters ++= Seq(
+      // private[this] constructor — not reachable by consumers
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem](
+          "org.http4s.otel4s.middleware.trace.client.ClientMiddleware#Impl.this"
+        )
+    ),
   )
 
 lazy val `trace-server` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -136,6 +143,13 @@ lazy val `trace-server` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "cats-effect" % catsEffectV,
       "org.http4s" %%% "http4s-server" % http4sV,
       "org.typelevel" %%% "otel4s-core-trace" % otel4sV,
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      // private[this] constructor — not reachable by consumers
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem](
+          "org.http4s.otel4s.middleware.trace.server.ServerMiddleware#Impl.this"
+        )
     ),
   )
 

--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
@@ -33,6 +33,7 @@ import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.StatusCode
 import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.Attributes
 
 /** A middleware for wrapping [[org.http4s.client.Client HTTP `Client`s]].
   *
@@ -65,6 +66,7 @@ object ClientMiddleware {
   private[this] class Impl[F[_]: MonadCancelThrow](
       tracer: Tracer[F],
       spanDataProvider: SpanDataProvider,
+      errorClassifier: ErrorClassifier,
       perRequestPropagationFilter: PerRequestFilter,
       perRequestTracingFilter: PerRequestFilter,
   ) extends ClientMiddleware[F] {
@@ -107,9 +109,14 @@ object ClientMiddleware {
                     fa.evalMap { resp =>
                       val respAttributes =
                         spanDataProvider.responseAttributes(resp.withBodyStream(Stream.empty))
-                      span.addAttributes(respAttributes) >> span
+                      val isError = errorClassifier.isError(resp.status)
+                      val errorAttributes =
+                        if (isError) spanDataProvider.errorAttributes(resp.status)
+                        else Attributes.empty
+
+                      span.addAttributes(respAttributes ++ errorAttributes) >> span
                         .setStatus(StatusCode.Error)
-                        .unlessA(resp.status.isSuccess)
+                        .whenA(isError)
                     }
 
                   case Outcome.Errored(e) =>
@@ -130,18 +137,33 @@ object ClientMiddleware {
   /** A builder for [[`ClientMiddleware`]]s that add tracing. */
   final class Builder[F[_]: MonadCancelThrow] private[ClientMiddleware] (
       spanDataProvider: SpanDataProvider,
+      errorClassifier: ErrorClassifier,
       perRequestPropagationFilter: PerRequestFilter,
       perRequestTracingFilter: PerRequestFilter,
   )(implicit tracerProvider: TracerProvider[F]) {
     private[this] def copy(
+        errorClassifier: ErrorClassifier = this.errorClassifier,
         perRequestPropagationFilter: PerRequestFilter = this.perRequestPropagationFilter,
         perRequestTracingFilter: PerRequestFilter = this.perRequestTracingFilter,
     ): Builder[F] =
       new Builder(
         spanDataProvider = this.spanDataProvider,
+        errorClassifier = errorClassifier,
         perRequestPropagationFilter = perRequestPropagationFilter,
         perRequestTracingFilter = perRequestTracingFilter,
       )
+
+    /** Sets how to determine whether the status of a response represents an
+      * error (defult: [[`ErrorClassifier.default`]]).
+      *
+      * @example
+      * {{{
+      * // a `404` response is an expected outcome of this client's requests
+      * builder.withErrorClassifier(ErrorClassifier.default.excluding(Status.NotFound))
+      * }}}
+      */
+    def withErrorClassifier(errorClassifier: ErrorClassifier): Builder[F] =
+      copy(errorClassifier = errorClassifier)
 
     /** Sets a filter that determines whether each request should propagate
       * tracing and other context information to the server (default: always
@@ -173,6 +195,7 @@ object ClientMiddleware {
       } yield new Impl(
         tracer = tracer,
         spanDataProvider = spanDataProvider,
+        errorClassifier = errorClassifier,
         perRequestPropagationFilter = perRequestPropagationFilter,
         perRequestTracingFilter = perRequestTracingFilter,
       )
@@ -187,6 +210,7 @@ object ClientMiddleware {
   ): Builder[F] =
     new Builder(
       spanDataProvider = spanDataProvider,
+      errorClassifier = ErrorClassifier.default,
       perRequestPropagationFilter = PerRequestFilter.alwaysEnabled,
       perRequestTracingFilter = PerRequestFilter.alwaysEnabled,
     )

--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
@@ -29,11 +29,11 @@ import cats.syntax.functor._
 import fs2.Stream
 import org.http4s.client.Client
 import org.http4s.client.Middleware
+import org.typelevel.otel4s.Attributes
 import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.StatusCode
 import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.otel4s.trace.TracerProvider
-import org.typelevel.otel4s.Attributes
 
 /** A middleware for wrapping [[org.http4s.client.Client HTTP `Client`s]].
   *

--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
@@ -155,7 +155,7 @@ object ClientMiddleware {
       )
 
     /** Sets how to determine whether the status of a response represents an
-      * error (defult: [[`ErrorClassifier.default`]]).
+      * error (default: [[ErrorClassifier.default]]).
       *
       * @example
       * {{{

--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddleware.scala
@@ -109,9 +109,10 @@ object ClientMiddleware {
                     fa.evalMap { resp =>
                       val respAttributes =
                         spanDataProvider.responseAttributes(resp.withBodyStream(Stream.empty))
-                      val isError = errorClassifier.isError(resp.status)
+                      val isError = errorClassifier.isError(reqPrelude, resp.responsePrelude)
                       val errorAttributes =
-                        if (isError) spanDataProvider.errorAttributes(resp.status)
+                        if (isError)
+                          spanDataProvider.errorAttributes(reqPrelude, resp.responsePrelude)
                         else Attributes.empty
 
                       span.addAttributes(respAttributes ++ errorAttributes) >> span

--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientSpanDataProvider.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientSpanDataProvider.scala
@@ -152,10 +152,9 @@ object ClientSpanDataProvider {
     def responseAttributes[F[_]](response: Response[F]): Attributes = {
       val b = Attributes.newBuilder
 
-      if (!response.status.isSuccess) {
-        // `error.type` for a `Throwable` handled by `exceptionAttributes`
-        b += TypedClientTraceAttributes.errorType(response.status)
-      }
+      // `error.type` for a response status is provided by `errorAttributes`,
+      // which the caller invokes only for statuses it considers to be errors;
+      // `error.type` for a `Throwable` is provided by `exceptionAttributes`
       b += TypedClientTraceAttributes.httpResponseStatusCode(response.status)
       optIn.httpResponseHeaders.foreach { redactor =>
         TypedClientTraceAttributes
@@ -167,6 +166,9 @@ object ClientSpanDataProvider {
 
     def exceptionAttributes(cause: Throwable): Attributes =
       Attributes(TypedClientTraceAttributes.errorType(cause))
+
+    def errorAttributes(status: Status): Attributes =
+      Attributes(TypedClientTraceAttributes.errorType(status))
 
     private def copy(
         urlTemplateClassifier: UriTemplateClassifier = this.urlTemplateClassifier,

--- a/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientSpanDataProvider.scala
+++ b/trace/client/src/main/scala/org/http4s/otel4s/middleware/trace/client/ClientSpanDataProvider.scala
@@ -167,8 +167,8 @@ object ClientSpanDataProvider {
     def exceptionAttributes(cause: Throwable): Attributes =
       Attributes(TypedClientTraceAttributes.errorType(cause))
 
-    def errorAttributes(status: Status): Attributes =
-      Attributes(TypedClientTraceAttributes.errorType(status))
+    override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+      Attributes(TypedClientTraceAttributes.errorType(response.status))
 
     private def copy(
         urlTemplateClassifier: UriTemplateClassifier = this.urlTemplateClassifier,

--- a/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareTest.scala
+++ b/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareTest.scala
@@ -217,6 +217,8 @@ class ClientMiddlewareTest extends CatsEffectSuite {
         Attributes.empty
       def exceptionAttributes(cause: Throwable): Attributes =
         Attributes.empty
+      def errorAttributes(status: Status): Attributes =
+        Attributes.empty
     }
 
     val spanName = "Overridden span name"
@@ -624,6 +626,315 @@ class ClientMiddlewareTest extends CatsEffectSuite {
           spans <- testkit.finishedSpans
         } yield assertEquals(spans.length, 0)
       }
+  }
+
+  test("treats 404 as an error by default") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ClientMiddleware
+            .builder[IO] {
+              ClientSpanDataProvider
+                .openTelemetry(MinimalRedactor)
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+                .optIntoUrlScheme
+                .optIntoUserAgentOriginal
+            }
+            .build
+            .flatMap { clientMiddleware =>
+              val client = clientMiddleware.wrapClient {
+                Client.fromHttpApp[IO] {
+                  HttpApp[IO](_.body.compile.drain.as(Response[IO](Status.NotFound)))
+                }
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+              val status = StatusData(StatusCode.Error)
+
+              val attributes = Attributes(
+                Attribute("error.type", "404"),
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 404L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("server.address", "localhost"),
+                Attribute("server.port", 80L),
+                Attribute("url.full", "http://localhost/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- client.run(request).use_
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(status))
+              }
+            }
+        }
+    }
+  }
+
+  test("does not treat a status excluded by the error classifier as an error") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ClientMiddleware
+            .builder[IO] {
+              ClientSpanDataProvider
+                .openTelemetry(MinimalRedactor)
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+                .optIntoUrlScheme
+                .optIntoUserAgentOriginal
+            }
+            .withErrorClassifier(ErrorClassifier.default.excluding(Status.NotFound))
+            .build
+            .flatMap { clientMiddleware =>
+              val client = clientMiddleware.wrapClient {
+                Client.fromHttpApp[IO] {
+                  HttpApp[IO](_.body.compile.drain.as(Response[IO](Status.NotFound)))
+                }
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+
+              val attributes = Attributes(
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 404L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("server.address", "localhost"),
+                Attribute("server.port", 80L),
+                Attribute("url.full", "http://localhost/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- client.run(request).use_
+                spans <- testkit.finishedSpans
+              } yield {
+                // No error.type attribute and status is Unset, not Error
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(StatusData.Unset))
+              }
+            }
+        }
+    }
+  }
+
+  test("still treats other error statuses as errors when on is excluded") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ClientMiddleware
+            .builder[IO] {
+              ClientSpanDataProvider
+                .openTelemetry(MinimalRedactor)
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+                .optIntoUrlScheme
+                .optIntoUserAgentOriginal
+            }
+            .withErrorClassifier(ErrorClassifier.default.excluding(Status.NotFound))
+            .build
+            .flatMap { clientMiddleware =>
+              val client = clientMiddleware.wrapClient {
+                Client.fromHttpApp[IO] {
+                  HttpApp[IO](_.body.compile.drain.as(Response[IO](Status.InternalServerError)))
+                }
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+              val status = StatusData(StatusCode.Error)
+
+              val attributes = Attributes(
+                Attribute("error.type", "500"),
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 500L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("server.address", "localhost"),
+                Attribute("server.port", 80L),
+                Attribute("url.full", "http://localhost/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- client.run(request).use_
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(status))
+              }
+            }
+        }
+    }
+  }
+
+  test("records error.type for a status the error classifier add") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ClientMiddleware
+            .builder[IO] {
+              ClientSpanDataProvider
+                .openTelemetry(MinimalRedactor)
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+                .optIntoUrlScheme
+                .optIntoUserAgentOriginal
+            }
+            .withErrorClassifier(ErrorClassifier.never.included(Status.Ok))
+            .build
+            .flatMap { clientMiddleware =>
+              val client = clientMiddleware.wrapClient {
+                Client.fromHttpApp[IO] {
+                  HttpApp[IO](_.body.compile.drain.as(Response[IO](Status.Ok)))
+                }
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+              val status = StatusData(StatusCode.Error)
+
+              val attributes = Attributes(
+                Attribute("error.type", "200"),
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 200L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("server.address", "localhost"),
+                Attribute("server.port", 80L),
+                Attribute("url.full", "http://localhost/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- client.run(request).use_
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(status))
+              }
+            }
+        }
+    }
+  }
+
+  test("never reports response statuses as errros with ErrorClassifier.never") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ClientMiddleware
+            .builder[IO] {
+              ClientSpanDataProvider
+                .openTelemetry(MinimalRedactor)
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+                .optIntoUrlScheme
+                .optIntoUserAgentOriginal
+            }
+            .withErrorClassifier(ErrorClassifier.never)
+            .build
+            .flatMap { clientMiddleware =>
+              val client = clientMiddleware.wrapClient {
+                Client.fromHttpApp[IO] {
+                  HttpApp[IO](_.body.compile.drain.as(Response[IO](Status.InternalServerError)))
+                }
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+
+              val attributes = Attributes(
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 500L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("server.address", "localhost"),
+                Attribute("server.port", 80L),
+                Attribute("url.full", "http://localhost/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- client.run(request).use_
+                spans <- testkit.finishedSpans
+              } yield {
+                // No error.type attribute and status is Unset, not Error
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(StatusData.Unset))
+              }
+            }
+        }
+    }
+  }
+
+  test("uses errorAttributes from the SpanDataProvider only for errors") {
+    val customErrorAttr = Attribute("custom.error.attribute", "error-value")
+    val provider: SpanDataProvider = new SpanDataProvider {
+      type Shared = Null
+      def processSharedData[F[_]](request: Request[F]): Null = null
+      def spanName[F[_]](request: Request[F], sharedProcessedData: Null): String =
+        "test-span"
+      def requestAttributes[F[_]](request: Request[F], sharedProcessedData: Null): Attributes =
+        Attributes.empty
+      def responseAttributes[F[_]](response: Response[F]): Attributes =
+        Attributes.empty
+      def exceptionAttributes(cause: Throwable): Attributes =
+        Attributes.empty
+      def errorAttributes(status: Status): Attributes =
+        Attributes(customErrorAttr)
+    }
+
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ClientMiddleware
+            .builder[IO](provider)
+            .build
+            .flatMap { clientMiddleware =>
+              val errorClient = clientMiddleware.wrapClient {
+                Client.fromHttpApp[IO] {
+                  HttpApp[IO](_.body.compile.drain.as(Response[IO](Status.BadRequest)))
+                }
+              }
+              val okClient = clientMiddleware.wrapClient {
+                Client.fromHttpApp[IO] {
+                  HttpApp[IO](_.body.compile.drain.as(Response[IO](Status.Ok)))
+                }
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+
+              for {
+                _ <- errorClient.run(request).use_
+                _ <- okClient.run(request).use_
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.length, 2)
+                val errorSpan = spans.find(_.status == StatusData(StatusCode.Error)).get
+                val okSpan = spans.find(_.status == StatusData.Unset).get
+                // Error span has the custom error attribute
+                assertEquals(
+                  errorSpan.attributes.elements.get[String]("custom.error.attribute").map(_.value),
+                  Some("error-value"),
+                )
+                // Ok span does NOT have the custom error attribute
+                assertEquals(
+                  okSpan.attributes.elements.get[String]("custom.error.attribute").map(_.value),
+                  None,
+                )
+              }
+            }
+        }
+    }
   }
 }
 

--- a/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareTest.scala
+++ b/trace/client/src/test/scala/org/http4s/otel4s/middleware/trace/client/ClientMiddlewareTest.scala
@@ -217,7 +217,7 @@ class ClientMiddlewareTest extends CatsEffectSuite {
         Attributes.empty
       def exceptionAttributes(cause: Throwable): Attributes =
         Attributes.empty
-      def errorAttributes(status: Status): Attributes =
+      override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
         Attributes.empty
     }
 
@@ -888,7 +888,7 @@ class ClientMiddlewareTest extends CatsEffectSuite {
         Attributes.empty
       def exceptionAttributes(cause: Throwable): Attributes =
         Attributes.empty
-      def errorAttributes(status: Status): Attributes =
+      override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
         Attributes(customErrorAttr)
     }
 

--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/AttributeProvider.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/AttributeProvider.scala
@@ -21,6 +21,7 @@ package trace
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.Attributes
 
+import scala.annotation.unused
 import scala.collection.immutable
 import scala.collection.immutable.ArraySeq
 
@@ -58,7 +59,10 @@ trait AttributeProvider {
   /** Provides attributes for a span based on a response that has been
     * determined to represent an error.
     */
-  def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+  def errorAttributes(
+      @unused request: RequestPrelude,
+      @unused response: ResponsePrelude,
+  ): Attributes =
     Attributes.empty
 
   /** @return an `AttributeProvider` that provides the attributes from this and

--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/AttributeProvider.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/AttributeProvider.scala
@@ -55,10 +55,11 @@ trait AttributeProvider {
   /** Provides attributes for a span based on a given exception. */
   def exceptionAttributes(cause: Throwable): Attributes
 
-  /** Provides attributes for a span based on a response status that has been
+  /** Provides attributes for a span based on a response that has been
     * determined to represent an error.
     */
-  def errorAttributes(status: Status): Attributes
+  def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+    Attributes.empty
 
   /** @return an `AttributeProvider` that provides the attributes from this and
     *         another `AttributeProvider`
@@ -77,7 +78,8 @@ object AttributeProvider {
     def requestAttributes[F[_]](request: Request[F]): Attributes = Attributes.empty
     def responseAttributes[F[_]](response: Response[F]): Attributes = Attributes.empty
     def exceptionAttributes(cause: Throwable): Attributes = Attributes.empty
-    def errorAttributes(status: Status): Attributes = Attributes.empty
+    override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+      Attributes.empty
 
     override def and(that: AttributeProvider): AttributeProvider = that
   }
@@ -95,8 +97,8 @@ object AttributeProvider {
         providers.foldLeft(Attributes.empty)(_ ++ _.responseAttributes(response))
       def exceptionAttributes(cause: Throwable): Attributes =
         providers.foldLeft(Attributes.empty)(_ ++ _.exceptionAttributes(cause))
-      def errorAttributes(status: Status): Attributes =
-        providers.foldLeft(Attributes.empty)(_ ++ _.errorAttributes(status))
+      override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+        providers.foldLeft(Attributes.empty)(_ ++ _.errorAttributes(request, response))
 
       override def and(that: AttributeProvider): AttributeProvider = that match {
         case Empty => this
@@ -118,7 +120,7 @@ object AttributeProvider {
       Attributes.empty
     def exceptionAttributes(cause: Throwable): Attributes =
       Attributes.empty
-    def errorAttributes(status: Status): Attributes =
+    override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
       Attributes.empty
 
     override def and(that: AttributeProvider): AttributeProvider = that match {

--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/AttributeProvider.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/AttributeProvider.scala
@@ -55,6 +55,11 @@ trait AttributeProvider {
   /** Provides attributes for a span based on a given exception. */
   def exceptionAttributes(cause: Throwable): Attributes
 
+  /** Provides attributes for a span based on a response status that has been
+    * determined to represent an error.
+    */
+  def errorAttributes(status: Status): Attributes
+
   /** @return an `AttributeProvider` that provides the attributes from this and
     *         another `AttributeProvider`
     */
@@ -72,6 +77,7 @@ object AttributeProvider {
     def requestAttributes[F[_]](request: Request[F]): Attributes = Attributes.empty
     def responseAttributes[F[_]](response: Response[F]): Attributes = Attributes.empty
     def exceptionAttributes(cause: Throwable): Attributes = Attributes.empty
+    def errorAttributes(status: Status): Attributes = Attributes.empty
 
     override def and(that: AttributeProvider): AttributeProvider = that
   }
@@ -89,6 +95,8 @@ object AttributeProvider {
         providers.foldLeft(Attributes.empty)(_ ++ _.responseAttributes(response))
       def exceptionAttributes(cause: Throwable): Attributes =
         providers.foldLeft(Attributes.empty)(_ ++ _.exceptionAttributes(cause))
+      def errorAttributes(status: Status): Attributes =
+        providers.foldLeft(Attributes.empty)(_ ++ _.errorAttributes(status))
 
       override def and(that: AttributeProvider): AttributeProvider = that match {
         case Empty => this
@@ -109,6 +117,8 @@ object AttributeProvider {
     def responseAttributes[F[_]](response: Response[F]): Attributes =
       Attributes.empty
     def exceptionAttributes(cause: Throwable): Attributes =
+      Attributes.empty
+    def errorAttributes(status: Status): Attributes =
       Attributes.empty
 
     override def and(that: AttributeProvider): AttributeProvider = that match {

--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/ErrorClassifier.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/ErrorClassifier.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package otel4s.middleware
+package trace
+
+trait ErrorClassifier {
+  def isError(status: Status): Boolean
+
+  def and(that: ErrorClassifier): ErrorClassifier =
+    status => isError(status) && that.isError(status)
+
+  def or(that: ErrorClassifier): ErrorClassifier =
+    status => isError(status) || that.isError(status)
+
+  def excluding(statuses: Status*): ErrorClassifier = {
+    val excluded = statuses.toSet
+    status => !excluded.contains(status) && isError(status)
+  }
+
+  def included(statuses: Status*): ErrorClassifier = {
+    val included = statuses.toSet
+    status => included.contains(status) || isError(status)
+  }
+}
+
+object ErrorClassifier {
+  val default: ErrorClassifier = { status =>
+    status.responseClass match {
+      case Status.ClientError | Status.ServerError => true
+      case _ => false
+    }
+  }
+
+  val serverError: ErrorClassifier =
+    _.responseClass == Status.ServerError
+
+  val never: ErrorClassifier = _ => false
+}

--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/ErrorClassifier.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/ErrorClassifier.scala
@@ -19,35 +19,34 @@ package otel4s.middleware
 package trace
 
 trait ErrorClassifier {
-  def isError(status: Status): Boolean
+  def isError(request: RequestPrelude, response: ResponsePrelude): Boolean
 
   def and(that: ErrorClassifier): ErrorClassifier =
-    status => isError(status) && that.isError(status)
+    (request, response) => isError(request, response) && that.isError(request, response)
 
   def or(that: ErrorClassifier): ErrorClassifier =
-    status => isError(status) || that.isError(status)
+    (request, response) => isError(request, response) || that.isError(request, response)
 
   def excluding(statuses: Status*): ErrorClassifier = {
     val excluded = statuses.toSet
-    status => !excluded.contains(status) && isError(status)
+    (request, response) => !excluded.contains(response.status) && isError(request, response)
   }
 
   def included(statuses: Status*): ErrorClassifier = {
     val included = statuses.toSet
-    status => included.contains(status) || isError(status)
+    (request, response) => included.contains(response.status) || isError(request, response)
   }
 }
 
 object ErrorClassifier {
-  val default: ErrorClassifier = { status =>
-    status.responseClass match {
+  val default: ErrorClassifier = (_, response) =>
+    response.status.responseClass match {
       case Status.ClientError | Status.ServerError => true
       case _ => false
     }
-  }
 
   val serverError: ErrorClassifier =
-    _.responseClass == Status.ServerError
+    (_, response) => response.status.responseClass == Status.ServerError
 
-  val never: ErrorClassifier = _ => false
+  val never: ErrorClassifier = (_, _) => false
 }

--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/SpanDataProvider.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/SpanDataProvider.scala
@@ -100,8 +100,10 @@ object SpanDataProvider {
       others.foldLeft(primary.responseAttributes(response))(_ ++ _.responseAttributes(response))
     def exceptionAttributes(cause: Throwable): Attributes =
       others.foldLeft(primary.exceptionAttributes(cause))(_ ++ _.exceptionAttributes(cause))
-    def errorAttributes(status: Status): Attributes =
-      others.foldLeft(primary.errorAttributes(status))(_ ++ _.errorAttributes(status))
+    override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+      others.foldLeft(primary.errorAttributes(request, response))(
+        _ ++ _.errorAttributes(request, response)
+      )
 
     override def and(that: AttributeProvider): SpanDataProvider = that match {
       case AttributeProvider.Empty => this

--- a/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/SpanDataProvider.scala
+++ b/trace/core/src/main/scala/org/http4s/otel4s/middleware/trace/SpanDataProvider.scala
@@ -100,6 +100,8 @@ object SpanDataProvider {
       others.foldLeft(primary.responseAttributes(response))(_ ++ _.responseAttributes(response))
     def exceptionAttributes(cause: Throwable): Attributes =
       others.foldLeft(primary.exceptionAttributes(cause))(_ ++ _.exceptionAttributes(cause))
+    def errorAttributes(status: Status): Attributes =
+      others.foldLeft(primary.errorAttributes(status))(_ ++ _.errorAttributes(status))
 
     override def and(that: AttributeProvider): SpanDataProvider = that match {
       case AttributeProvider.Empty => this

--- a/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/AttributeProviderTest.scala
+++ b/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/AttributeProviderTest.scala
@@ -25,6 +25,7 @@ class AttributeProviderTest extends FunSuite {
     val p = AttributeProvider.const(Attribute("key", "value"))
     assertEquals(p.requestAttributes(null), Attributes(Attribute("key", "value")))
     assert(p.responseAttributes(null).isEmpty)
+    assert(p.errorAttributes(null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
   }
 
@@ -33,6 +34,7 @@ class AttributeProviderTest extends FunSuite {
     val p = AttributeProvider.const(attributes)
     assert(p.requestAttributes(null) eq attributes)
     assert(p.responseAttributes(null).isEmpty)
+    assert(p.errorAttributes(null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
   }
 
@@ -45,6 +47,7 @@ class AttributeProviderTest extends FunSuite {
       Attributes(Attribute("foo", "bar"), Attribute("baz", "qux")),
     )
     assert(p.responseAttributes(null).isEmpty)
+    assert(p.errorAttributes(null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
     assert(p.requestAttributes(null) eq p.requestAttributes(null))
 
@@ -65,6 +68,7 @@ class AttributeProviderTest extends FunSuite {
       ),
     )
     assert(p.responseAttributes(null).isEmpty)
+    assert(p.errorAttributes(null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
   }
 }

--- a/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/AttributeProviderTest.scala
+++ b/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/AttributeProviderTest.scala
@@ -25,7 +25,7 @@ class AttributeProviderTest extends FunSuite {
     val p = AttributeProvider.const(Attribute("key", "value"))
     assertEquals(p.requestAttributes(null), Attributes(Attribute("key", "value")))
     assert(p.responseAttributes(null).isEmpty)
-    assert(p.errorAttributes(null).isEmpty)
+    assert(p.errorAttributes(null, null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
   }
 
@@ -34,7 +34,7 @@ class AttributeProviderTest extends FunSuite {
     val p = AttributeProvider.const(attributes)
     assert(p.requestAttributes(null) eq attributes)
     assert(p.responseAttributes(null).isEmpty)
-    assert(p.errorAttributes(null).isEmpty)
+    assert(p.errorAttributes(null, null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
   }
 
@@ -47,7 +47,7 @@ class AttributeProviderTest extends FunSuite {
       Attributes(Attribute("foo", "bar"), Attribute("baz", "qux")),
     )
     assert(p.responseAttributes(null).isEmpty)
-    assert(p.errorAttributes(null).isEmpty)
+    assert(p.errorAttributes(null, null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
     assert(p.requestAttributes(null) eq p.requestAttributes(null))
 
@@ -68,7 +68,7 @@ class AttributeProviderTest extends FunSuite {
       ),
     )
     assert(p.responseAttributes(null).isEmpty)
-    assert(p.errorAttributes(null).isEmpty)
+    assert(p.errorAttributes(null, null).isEmpty)
     assert(p.exceptionAttributes(null).isEmpty)
   }
 }

--- a/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/ErrorClassifierTest.scala
+++ b/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/ErrorClassifierTest.scala
@@ -18,12 +18,27 @@ package org.http4s
 package otel4s.middleware.trace
 
 import munit.FunSuite
+import org.http4s.implicits._
 
 class ErrorClassifierTest extends FunSuite {
+  private def reqPrelude: RequestPrelude =
+    RequestPrelude(
+      headers = Headers.empty,
+      httpVersion = HttpVersion.`HTTP/1.1`,
+      method = Method.GET,
+      uri = uri"http://localhost/",
+    )
+
+  private def respPrelude(status: Status): ResponsePrelude =
+    ResponsePrelude(
+      headers = Headers.empty,
+      httpVersion = HttpVersion.`HTTP/1.1`,
+      status = status,
+    )
 
   test("default classifies 4xx and 5xx as errors") {
     def check(status: Status, expected: Boolean): Unit =
-      assertEquals(ErrorClassifier.default.isError(status), expected)
+      assertEquals(ErrorClassifier.default.isError(reqPrelude, respPrelude(status)), expected)
 
     check(Status.Ok, false)
     check(Status.Created, false)
@@ -41,7 +56,7 @@ class ErrorClassifierTest extends FunSuite {
 
   test("serverError classifies only 5xx as errors") {
     def check(status: Status, expected: Boolean): Unit =
-      assertEquals(ErrorClassifier.serverError.isError(status), expected)
+      assertEquals(ErrorClassifier.serverError.isError(reqPrelude, respPrelude(status)), expected)
 
     check(Status.Ok, false)
     check(Status.BadRequest, false)
@@ -54,7 +69,7 @@ class ErrorClassifierTest extends FunSuite {
 
   test("never classifies nothing as an error") {
     def check(status: Status): Unit =
-      assertEquals(ErrorClassifier.never.isError(status), false)
+      assertEquals(ErrorClassifier.never.isError(reqPrelude, respPrelude(status)), false)
 
     check(Status.Ok)
     check(Status.BadRequest)
@@ -65,73 +80,82 @@ class ErrorClassifierTest extends FunSuite {
     val classifier = ErrorClassifier.default.and(ErrorClassifier.serverError)
 
     // default = 4xx || 5xx, serverError = 5xx → AND = 5xx only
-    assertEquals(classifier.isError(Status.Ok), false)
-    assertEquals(classifier.isError(Status.BadRequest), false)
-    assertEquals(classifier.isError(Status.NotFound), false)
-    assertEquals(classifier.isError(Status.InternalServerError), true)
-    assertEquals(classifier.isError(Status.BadGateway), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.Ok)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadRequest)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.NotFound)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.InternalServerError)), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadGateway)), true)
   }
 
   test("or combines two classifiers with logical OR") {
     val classifier = ErrorClassifier.serverError.or(ErrorClassifier.never)
 
     // serverError = 5xx, never = none → OR = 5xx only
-    assertEquals(classifier.isError(Status.Ok), false)
-    assertEquals(classifier.isError(Status.BadRequest), false)
-    assertEquals(classifier.isError(Status.InternalServerError), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.Ok)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadRequest)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.InternalServerError)), true)
   }
 
   test("excluding removes specific statuses from the classifier") {
     val classifier = ErrorClassifier.default.excluding(Status.NotFound, Status.InternalServerError)
 
-    assertEquals(classifier.isError(Status.Ok), false)
-    assertEquals(classifier.isError(Status.BadRequest), true)
-    assertEquals(classifier.isError(Status.NotFound), false)
-    assertEquals(classifier.isError(Status.InternalServerError), false)
-    assertEquals(classifier.isError(Status.BadGateway), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.Ok)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadRequest)), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.NotFound)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.InternalServerError)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadGateway)), true)
   }
 
   test("included adds specific statuses to the classifier") {
     val classifier = ErrorClassifier.serverError.included(Status.Ok, Status.BadRequest)
 
-    assertEquals(classifier.isError(Status.Ok), true)
-    assertEquals(classifier.isError(Status.BadRequest), true)
-    assertEquals(classifier.isError(Status.NotFound), false)
-    assertEquals(classifier.isError(Status.InternalServerError), true)
-    assertEquals(classifier.isError(Status.BadGateway), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.Ok)), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadRequest)), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.NotFound)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.InternalServerError)), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadGateway)), true)
   }
 
   test("custom classifier created from a lambda") {
-    val onlyNotFound: ErrorClassifier = _ == Status.NotFound
+    val onlyNotFound: ErrorClassifier = (_, response) => response.status == Status.NotFound
 
-    assertEquals(onlyNotFound.isError(Status.Ok), false)
-    assertEquals(onlyNotFound.isError(Status.BadRequest), false)
-    assertEquals(onlyNotFound.isError(Status.NotFound), true)
-    assertEquals(onlyNotFound.isError(Status.InternalServerError), false)
+    assertEquals(onlyNotFound.isError(reqPrelude, respPrelude(Status.Ok)), false)
+    assertEquals(onlyNotFound.isError(reqPrelude, respPrelude(Status.BadRequest)), false)
+    assertEquals(onlyNotFound.isError(reqPrelude, respPrelude(Status.NotFound)), true)
+    assertEquals(onlyNotFound.isError(reqPrelude, respPrelude(Status.InternalServerError)), false)
   }
 
   test("excluding on never classifier has no effect") {
     val classifier = ErrorClassifier.never.excluding(Status.InternalServerError)
 
-    assertEquals(classifier.isError(Status.Ok), false)
-    assertEquals(classifier.isError(Status.InternalServerError), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.Ok)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.InternalServerError)), false)
   }
 
   test("included on never classifier adds statuses") {
     val classifier = ErrorClassifier.never.included(Status.BadRequest)
 
-    assertEquals(classifier.isError(Status.Ok), false)
-    assertEquals(classifier.isError(Status.BadRequest), true)
-    assertEquals(classifier.isError(Status.InternalServerError), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.Ok)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadRequest)), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.InternalServerError)), false)
   }
 
   test("excluding and included can be chained") {
     val classifier =
       ErrorClassifier.default.excluding(Status.BadRequest).included(Status.Ok)
 
-    assertEquals(classifier.isError(Status.Ok), true)
-    assertEquals(classifier.isError(Status.BadRequest), false)
-    assertEquals(classifier.isError(Status.NotFound), true)
-    assertEquals(classifier.isError(Status.InternalServerError), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.Ok)), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.BadRequest)), false)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.NotFound)), true)
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.InternalServerError)), true)
+  }
+
+  test("classification can depend on request method") {
+    val classifier: ErrorClassifier =
+      (request, response) => response.status == Status.NotFound && request.method == Method.GET
+
+    assertEquals(classifier.isError(reqPrelude, respPrelude(Status.NotFound)), true)
+    val postReq = reqPrelude.withMethod(Method.POST)
+    assertEquals(classifier.isError(postReq, respPrelude(Status.NotFound)), false)
   }
 }

--- a/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/ErrorClassifierTest.scala
+++ b/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/ErrorClassifierTest.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2023 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package otel4s.middleware.trace
+
+import munit.FunSuite
+
+class ErrorClassifierTest extends FunSuite {
+
+  test("default classifies 4xx and 5xx as errors") {
+    def check(status: Status, expected: Boolean): Unit =
+      assertEquals(ErrorClassifier.default.isError(status), expected)
+
+    check(Status.Ok, false)
+    check(Status.Created, false)
+    check(Status.NoContent, false)
+    check(Status.MovedPermanently, false)
+    check(Status.BadRequest, true)
+    check(Status.Unauthorized, true)
+    check(Status.Forbidden, true)
+    check(Status.NotFound, true)
+    check(Status.InternalServerError, true)
+    check(Status.NotImplemented, true)
+    check(Status.BadGateway, true)
+    check(Status.ServiceUnavailable, true)
+  }
+
+  test("serverError classifies only 5xx as errors") {
+    def check(status: Status, expected: Boolean): Unit =
+      assertEquals(ErrorClassifier.serverError.isError(status), expected)
+
+    check(Status.Ok, false)
+    check(Status.BadRequest, false)
+    check(Status.NotFound, false)
+    check(Status.InternalServerError, true)
+    check(Status.NotImplemented, true)
+    check(Status.BadGateway, true)
+    check(Status.ServiceUnavailable, true)
+  }
+
+  test("never classifies nothing as an error") {
+    def check(status: Status): Unit =
+      assertEquals(ErrorClassifier.never.isError(status), false)
+
+    check(Status.Ok)
+    check(Status.BadRequest)
+    check(Status.InternalServerError)
+  }
+
+  test("and combines two classifiers with logical AND") {
+    val classifier = ErrorClassifier.default.and(ErrorClassifier.serverError)
+
+    // default = 4xx || 5xx, serverError = 5xx → AND = 5xx only
+    assertEquals(classifier.isError(Status.Ok), false)
+    assertEquals(classifier.isError(Status.BadRequest), false)
+    assertEquals(classifier.isError(Status.NotFound), false)
+    assertEquals(classifier.isError(Status.InternalServerError), true)
+    assertEquals(classifier.isError(Status.BadGateway), true)
+  }
+
+  test("or combines two classifiers with logical OR") {
+    val classifier = ErrorClassifier.serverError.or(ErrorClassifier.never)
+
+    // serverError = 5xx, never = none → OR = 5xx only
+    assertEquals(classifier.isError(Status.Ok), false)
+    assertEquals(classifier.isError(Status.BadRequest), false)
+    assertEquals(classifier.isError(Status.InternalServerError), true)
+  }
+
+  test("excluding removes specific statuses from the classifier") {
+    val classifier = ErrorClassifier.default.excluding(Status.NotFound, Status.InternalServerError)
+
+    assertEquals(classifier.isError(Status.Ok), false)
+    assertEquals(classifier.isError(Status.BadRequest), true)
+    assertEquals(classifier.isError(Status.NotFound), false)
+    assertEquals(classifier.isError(Status.InternalServerError), false)
+    assertEquals(classifier.isError(Status.BadGateway), true)
+  }
+
+  test("included adds specific statuses to the classifier") {
+    val classifier = ErrorClassifier.serverError.included(Status.Ok, Status.BadRequest)
+
+    assertEquals(classifier.isError(Status.Ok), true)
+    assertEquals(classifier.isError(Status.BadRequest), true)
+    assertEquals(classifier.isError(Status.NotFound), false)
+    assertEquals(classifier.isError(Status.InternalServerError), true)
+    assertEquals(classifier.isError(Status.BadGateway), true)
+  }
+
+  test("custom classifier created from a lambda") {
+    val onlyNotFound: ErrorClassifier = _ == Status.NotFound
+
+    assertEquals(onlyNotFound.isError(Status.Ok), false)
+    assertEquals(onlyNotFound.isError(Status.BadRequest), false)
+    assertEquals(onlyNotFound.isError(Status.NotFound), true)
+    assertEquals(onlyNotFound.isError(Status.InternalServerError), false)
+  }
+
+  test("excluding on never classifier has no effect") {
+    val classifier = ErrorClassifier.never.excluding(Status.InternalServerError)
+
+    assertEquals(classifier.isError(Status.Ok), false)
+    assertEquals(classifier.isError(Status.InternalServerError), false)
+  }
+
+  test("included on never classifier adds statuses") {
+    val classifier = ErrorClassifier.never.included(Status.BadRequest)
+
+    assertEquals(classifier.isError(Status.Ok), false)
+    assertEquals(classifier.isError(Status.BadRequest), true)
+    assertEquals(classifier.isError(Status.InternalServerError), false)
+  }
+
+  test("excluding and included can be chained") {
+    val classifier =
+      ErrorClassifier.default.excluding(Status.BadRequest).included(Status.Ok)
+
+    assertEquals(classifier.isError(Status.Ok), true)
+    assertEquals(classifier.isError(Status.BadRequest), false)
+    assertEquals(classifier.isError(Status.NotFound), true)
+    assertEquals(classifier.isError(Status.InternalServerError), true)
+  }
+}

--- a/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/SpanDataProviderTest.scala
+++ b/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/SpanDataProviderTest.scala
@@ -38,7 +38,7 @@ class SpanDataProviderTest extends FunSuite {
       assertEquals(provider.requestAttributes(null), expected, "requestAttributes")
       assertEquals(provider.responseAttributes(null), expected, "responseAttributes")
       assertEquals(provider.exceptionAttributes(null), expected, "exceptionAttributes")
-      assertEquals(provider.errorAttributes(null), expected, "errorAttributes")
+      assertEquals(provider.errorAttributes(null, null), expected, "errorAttributes")
     }
 
     val a = new SimpleAttributeProvider("a")
@@ -86,7 +86,8 @@ object SpanDataProviderTest {
     def requestAttributes[F[_]](request: Request[F]): Attributes = attr(name)
     def responseAttributes[F[_]](response: Response[F]): Attributes = attr(name)
     def exceptionAttributes(cause: Throwable): Attributes = attr(name)
-    def errorAttributes(status: Status): Attributes = attr(name)
+    override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+      attr(name)
   }
 
   private final class SimpleSpanDataProvider(name: String) extends SpanDataProvider {
@@ -97,6 +98,7 @@ object SpanDataProviderTest {
       attr(name)
     def responseAttributes[F[_]](response: Response[F]): Attributes = attr(name)
     def exceptionAttributes(cause: Throwable): Attributes = attr(name)
-    def errorAttributes(status: Status): Attributes = attr(name)
+    override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+      attr(name)
   }
 }

--- a/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/SpanDataProviderTest.scala
+++ b/trace/core/src/test/scala/org/http4s/otel4s/middleware/trace/SpanDataProviderTest.scala
@@ -38,6 +38,7 @@ class SpanDataProviderTest extends FunSuite {
       assertEquals(provider.requestAttributes(null), expected, "requestAttributes")
       assertEquals(provider.responseAttributes(null), expected, "responseAttributes")
       assertEquals(provider.exceptionAttributes(null), expected, "exceptionAttributes")
+      assertEquals(provider.errorAttributes(null), expected, "errorAttributes")
     }
 
     val a = new SimpleAttributeProvider("a")
@@ -85,6 +86,7 @@ object SpanDataProviderTest {
     def requestAttributes[F[_]](request: Request[F]): Attributes = attr(name)
     def responseAttributes[F[_]](response: Response[F]): Attributes = attr(name)
     def exceptionAttributes(cause: Throwable): Attributes = attr(name)
+    def errorAttributes(status: Status): Attributes = attr(name)
   }
 
   private final class SimpleSpanDataProvider(name: String) extends SpanDataProvider {
@@ -95,5 +97,6 @@ object SpanDataProviderTest {
       attr(name)
     def responseAttributes[F[_]](response: Response[F]): Attributes = attr(name)
     def exceptionAttributes(cause: Throwable): Attributes = attr(name)
+    def errorAttributes(status: Status): Attributes = attr(name)
   }
 }

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
@@ -29,11 +29,11 @@ import cats.syntax.functor._
 import fs2.Stream
 import org.http4s.server.HttpMiddleware
 import org.http4s.server.Middleware
+import org.typelevel.otel4s.Attributes
 import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.StatusCode
 import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.otel4s.trace.TracerProvider
-import org.typelevel.otel4s.Attributes
 
 /** A middleware for wrapping [[org.http4s.HttpApp `HttpApp`]],
   * [[org.http4s.HttpRoutes `HttpRoutes`]], and arbitrary

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
@@ -212,7 +212,7 @@ object ServerMiddleware {
       )
 
     /** Sets how to determine whether the status of a response represents an
-      * error (default: [[`ErrorClassifier.serverError`]]).
+      * error (default: [[ErrorClassifier.serverError]]).
       */
     def withErrorClassifier(errorClassifier: ErrorClassifier): Builder[F] =
       copy(errorClassifier = errorClassifier)

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
@@ -33,6 +33,7 @@ import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.StatusCode
 import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.otel4s.trace.TracerProvider
+import org.typelevel.otel4s.Attributes
 
 /** A middleware for wrapping [[org.http4s.HttpApp `HttpApp`]],
   * [[org.http4s.HttpRoutes `HttpRoutes`]], and arbitrary
@@ -126,6 +127,7 @@ object ServerMiddleware {
   private[this] final class Impl[F[_]](
       tracerF: Tracer[F],
       spanDataProvider: SpanDataProvider,
+      errorClassifier: ErrorClassifier,
       perRequestReversePropagationFilter: PerRequestFilter,
       perRequestTracingFilter: PerRequestFilter,
   )(implicit val monadCancelThrow: MonadCancelThrow[F])
@@ -167,9 +169,13 @@ object ServerMiddleware {
                       fa.flatMap { resp =>
                         val respAttributes =
                           spanDataProvider.responseAttributes(resp.withBodyStream(Stream.empty))
-                        span.addAttributes(respAttributes) >> span
+                        val isError = errorClassifier.isError(resp.status)
+                        val errorAttributes =
+                          if (isError) spanDataProvider.errorAttributes(resp.status)
+                          else Attributes.empty
+                        span.addAttributes(respAttributes ++ errorAttributes) >> span
                           .setStatus(StatusCode.Error)
-                          .whenA(resp.status.responseClass == Status.ServerError)
+                          .whenA(isError)
                       }
                     case Outcome.Errored(e) =>
                       span.addAttributes(spanDataProvider.exceptionAttributes(e))
@@ -187,19 +193,28 @@ object ServerMiddleware {
   /** A builder for [[`ServerMiddleware`]]s that add tracing. */
   final class Builder[F[_]: MonadCancelThrow] private[ServerMiddleware] (
       spanDataProvider: SpanDataProvider,
+      errorClassifier: ErrorClassifier,
       perRequestReversePropagationFilter: PerRequestFilter,
       perRequestTracingFilter: PerRequestFilter,
   )(implicit tracerProvider: TracerProvider[F]) {
     private[this] def copy(
+        errorClassifier: ErrorClassifier = this.errorClassifier,
         perRequestReversePropagationFilter: PerRequestFilter =
           this.perRequestReversePropagationFilter,
         perRequestTracingFilter: PerRequestFilter = this.perRequestTracingFilter,
     ): Builder[F] =
       new Builder(
         spanDataProvider = this.spanDataProvider,
+        errorClassifier = errorClassifier,
         perRequestReversePropagationFilter = perRequestReversePropagationFilter,
         perRequestTracingFilter = perRequestTracingFilter,
       )
+
+    /** Sets how to determine whether the status of a response represents an
+      * error (default: [[`ErrorClassifier.serverError`]]).
+      */
+    def withErrorClassifier(errorClassifier: ErrorClassifier): Builder[F] =
+      copy(errorClassifier = errorClassifier)
 
     /** Sets a filter that determines whether each request should propagate
       * tracing and other context information back to the requesting client in
@@ -232,6 +247,7 @@ object ServerMiddleware {
       } yield new Impl(
         tracerF = tracer,
         spanDataProvider = spanDataProvider,
+        errorClassifier = errorClassifier,
         perRequestReversePropagationFilter = perRequestReversePropagationFilter,
         perRequestTracingFilter = perRequestTracingFilter,
       )
@@ -246,6 +262,7 @@ object ServerMiddleware {
   ): Builder[F] =
     new Builder[F](
       spanDataProvider = spanDataProvider,
+      errorClassifier = ErrorClassifier.serverError,
       perRequestReversePropagationFilter = PerRequestFilter.neverEnabled,
       perRequestTracingFilter = PerRequestFilter.alwaysEnabled,
     )

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddleware.scala
@@ -169,9 +169,10 @@ object ServerMiddleware {
                       fa.flatMap { resp =>
                         val respAttributes =
                           spanDataProvider.responseAttributes(resp.withBodyStream(Stream.empty))
-                        val isError = errorClassifier.isError(resp.status)
+                        val isError = errorClassifier.isError(reqPrelude, resp.responsePrelude)
                         val errorAttributes =
-                          if (isError) spanDataProvider.errorAttributes(resp.status)
+                          if (isError)
+                            spanDataProvider.errorAttributes(reqPrelude, resp.responsePrelude)
                           else Attributes.empty
                         span.addAttributes(respAttributes ++ errorAttributes) >> span
                           .setStatus(StatusCode.Error)

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerSpanDataProvider.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerSpanDataProvider.scala
@@ -146,10 +146,9 @@ object ServerSpanDataProvider {
     def responseAttributes[F[_]](response: Response[F]): Attributes = {
       val b = Attributes.newBuilder
 
-      if (response.status.responseClass == Status.ServerError) {
-        // `error.type` for a `Throwable` handled by `exceptionAttributes`
-        b += TypedServerTraceAttributes.errorType(response.status)
-      }
+      // `error.type` for a response status is provided by `errorAttributes`,
+      // which the caller invokes only for statuses it considers to be errors;
+      // `error.type` for a `Throwable` is provided by `exceptionAttributes`
       b += TypedServerTraceAttributes.httpResponseStatusCode(response.status)
       optIn.httpResponseHeaders.foreach { redactor =>
         TypedServerTraceAttributes
@@ -161,6 +160,9 @@ object ServerSpanDataProvider {
 
     def exceptionAttributes(cause: Throwable): Attributes =
       Attributes(TypedServerTraceAttributes.errorType(cause))
+
+    def errorAttributes(status: Status): Attributes =
+      Attributes(TypedServerTraceAttributes.errorType(status))
 
     private[this] def copy(
         routeClassifier: RouteClassifier = this.routeClassifier,

--- a/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerSpanDataProvider.scala
+++ b/trace/server/src/main/scala/org/http4s/otel4s/middleware/trace/server/ServerSpanDataProvider.scala
@@ -161,8 +161,8 @@ object ServerSpanDataProvider {
     def exceptionAttributes(cause: Throwable): Attributes =
       Attributes(TypedServerTraceAttributes.errorType(cause))
 
-    def errorAttributes(status: Status): Attributes =
-      Attributes(TypedServerTraceAttributes.errorType(status))
+    override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
+      Attributes(TypedServerTraceAttributes.errorType(response.status))
 
     private[this] def copy(
         routeClassifier: RouteClassifier = this.routeClassifier,

--- a/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTest.scala
+++ b/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTest.scala
@@ -457,6 +457,284 @@ class ServerMiddlewareTest extends CatsEffectSuite {
   suite("asHttpRoutesMiddleware") { (sm, app) =>
     sm.asHttpRoutesMiddleware(app.mapK(OptionT.liftK)).orNotFound
   }
+
+  test("treats 500 as an error by default") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ServerMiddleware
+            .builder[IO] {
+              ServerSpanDataProvider
+                .openTelemetry(NoopRedactor)
+                .optIntoClientPort
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+            }
+            .build
+            .flatMap { serverMiddleware =>
+              val app = serverMiddleware.wrapHttpApp {
+                HttpApp[IO](_ => IO.pure(Response[IO](Status.InternalServerError)))
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+              val status = StatusData(StatusCode.Error)
+
+              val attributes = Attributes(
+                Attribute("error.type", "500"),
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 500L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("url.path", "/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- app.run(request).attempt
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(status))
+              }
+            }
+        }
+    }
+  }
+
+  test("does not treat a status excluded by the error classifier as an error") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ServerMiddleware
+            .builder[IO] {
+              ServerSpanDataProvider
+                .openTelemetry(NoopRedactor)
+                .optIntoClientPort
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+            }
+            .withErrorClassifier(ErrorClassifier.serverError.excluding(Status.InternalServerError))
+            .build
+            .flatMap { serverMiddleware =>
+              val app = serverMiddleware.wrapHttpApp {
+                HttpApp[IO](_ => IO.pure(Response[IO](Status.InternalServerError)))
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+
+              val attributes = Attributes(
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 500L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("url.path", "/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- app.run(request).attempt
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(StatusData.Unset))
+              }
+            }
+        }
+    }
+  }
+
+  test("still treats other error statuses as errors when on is excluded") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ServerMiddleware
+            .builder[IO] {
+              ServerSpanDataProvider
+                .openTelemetry(NoopRedactor)
+                .optIntoClientPort
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+            }
+            .withErrorClassifier(ErrorClassifier.serverError.excluding(Status.InternalServerError))
+            .build
+            .flatMap { serverMiddleware =>
+              val app = serverMiddleware.wrapHttpApp {
+                HttpApp[IO](_ => IO.pure(Response[IO](Status.ServiceUnavailable)))
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+              val status = StatusData(StatusCode.Error)
+
+              val attributes = Attributes(
+                Attribute("error.type", "503"),
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 503L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("url.path", "/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- app.run(request).attempt
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(status))
+              }
+            }
+        }
+    }
+  }
+
+  test("records error.type for a status the error classifier add") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ServerMiddleware
+            .builder[IO] {
+              ServerSpanDataProvider
+                .openTelemetry(NoopRedactor)
+                .optIntoClientPort
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+            }
+            .withErrorClassifier(ErrorClassifier.never.included(Status.Ok))
+            .build
+            .flatMap { serverMiddleware =>
+              val app = serverMiddleware.wrapHttpApp {
+                HttpApp[IO](_ => IO.pure(Response[IO](Status.Ok)))
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+              val status = StatusData(StatusCode.Error)
+
+              val attributes = Attributes(
+                Attribute("error.type", "200"),
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 200L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("url.path", "/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- app.run(request).attempt
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(status))
+              }
+            }
+        }
+    }
+  }
+
+  test("never reports response statuses as errros with ErrorClassifier.never") {
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ServerMiddleware
+            .builder[IO] {
+              ServerSpanDataProvider
+                .openTelemetry(NoopRedactor)
+                .optIntoClientPort
+                .optIntoHttpRequestHeaders(HeaderRedactor.default)
+                .optIntoHttpResponseHeaders(HeaderRedactor.default)
+            }
+            .withErrorClassifier(ErrorClassifier.never)
+            .build
+            .flatMap { serverMiddleware =>
+              val app = serverMiddleware.wrapHttpApp {
+                HttpApp[IO](_ => IO.pure(Response[IO](Status.InternalServerError)))
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+
+              val attributes = Attributes(
+                Attribute("http.request.method", "GET"),
+                Attribute("http.response.status_code", 500L),
+                Attribute("network.protocol.version", "1.1"),
+                Attribute("url.path", "/"),
+                Attribute("url.scheme", "http"),
+              )
+
+              for {
+                _ <- app.run(request).attempt
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.map(_.attributes.elements), List(attributes))
+                assertEquals(spans.flatMap(_.events.elements), Nil)
+                assertEquals(spans.map(_.status), List(StatusData.Unset))
+              }
+            }
+        }
+    }
+  }
+
+  test("uses errorAttributes from the SpanDataProvider only for errors") {
+    val customErrorAttr = Attribute("custom.error.attribute", "error-value")
+    val provider: SpanDataProvider = new SpanDataProvider {
+      type Shared = Null
+      def processSharedData[F[_]](request: Request[F]): Null = null
+      def spanName[F[_]](request: Request[F], sharedProcessedData: Null): String =
+        "test-span"
+      def requestAttributes[F[_]](request: Request[F], sharedProcessedData: Null): Attributes =
+        Attributes.empty
+      def responseAttributes[F[_]](response: Response[F]): Attributes =
+        Attributes.empty
+      def exceptionAttributes(cause: Throwable): Attributes =
+        Attributes.empty
+      def errorAttributes(status: Status): Attributes =
+        Attributes(customErrorAttr)
+    }
+
+    TestControl.executeEmbed {
+      TracesTestkit
+        .inMemory[IO]()
+        .use { testkit =>
+          implicit val TP: TracerProvider[IO] = testkit.tracerProvider
+          ServerMiddleware
+            .builder[IO](provider)
+            .build
+            .flatMap { serverMiddleware =>
+              val errorApp = serverMiddleware.wrapHttpApp {
+                HttpApp[IO](_ => IO.pure(Response[IO](Status.InternalServerError)))
+              }
+              val okApp = serverMiddleware.wrapHttpApp {
+                HttpApp[IO](_ => IO.pure(Response[IO](Status.Ok)))
+              }
+              val request = Request[IO](Method.GET, uri"http://localhost/")
+
+              for {
+                _ <- errorApp.run(request).attempt
+                _ <- okApp.run(request).attempt
+                spans <- testkit.finishedSpans
+              } yield {
+                assertEquals(spans.length, 2)
+                val errorSpan = spans.find(_.status == StatusData(StatusCode.Error)).get
+                val okSpan = spans.find(_.status == StatusData.Unset).get
+                // Error span has the custom error attribute
+                assertEquals(
+                  errorSpan.attributes.elements.get[String]("custom.error.attribute").map(_.value),
+                  Some("error-value"),
+                )
+                // Ok span does NOT have the custom error attribute
+                assertEquals(
+                  okSpan.attributes.elements.get[String]("custom.error.attribute").map(_.value),
+                  None,
+                )
+              }
+            }
+        }
+    }
+  }
 }
 
 object ServerMiddlewareTest {

--- a/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTest.scala
+++ b/trace/server/src/test/scala/org/http4s/otel4s/middleware/trace/server/ServerMiddlewareTest.scala
@@ -691,7 +691,7 @@ class ServerMiddlewareTest extends CatsEffectSuite {
         Attributes.empty
       def exceptionAttributes(cause: Throwable): Attributes =
         Attributes.empty
-      def errorAttributes(status: Status): Attributes =
+      override def errorAttributes(request: RequestPrelude, response: ResponsePrelude): Attributes =
         Attributes(customErrorAttr)
     }
 


### PR DESCRIPTION
Allows clients to treat specific statuses like 404 or other 4xx as non-errors, and servers to customize which statuses are considered errors. Previously, the server hard-coded 5xx and the client hard-coded 3xx+4xx+5xx as errors, with no way to customize.

3xx redirect statuses were incorrectly treated as errors on the client side, contradicting the OpenTelemetry HTTP semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status

Fixes #328 